### PR TITLE
perf(playback): route playhead updates outside pipeline store

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -374,8 +374,8 @@ import type {
 | `PlaybackOverlayContribution` | Registers a region above playback track (`id`, optional `order`, optional `height`, `render(context)`). |
 | `TimelineOverlayContribution` | Alias of `PlaybackOverlayContribution` for naming clarity. |
 | `RosViewExtensionContext` | Stable context object passed into extension renderers. |
-| `PlaybackControlsApi` | Playback controls: `seek`, `play`, `pause`, `setSpeed`, `setLooping`, `stepBy`, `stepMessage`, `playUntil`, `subscribeCurrentTime`, `getSnapshot`. |
-| `PlaybackSnapshot` | Playback state including `currentTime`, `startTime`, `endTime`, `isPlaying`, `speed`, optional `progressPercent`, `buffering`, `problems`. |
+| `PlaybackControlsApi` | Playback controls: `seek`, `play`, `pause`, `setSpeed`, `setLooping`, `stepBy`, `stepMessage`, `playUntil`, `subscribeCurrentTime`, `getCurrentTime`, `getSnapshot`. |
+| `PlaybackSnapshot` | Low-frequency playback state including `currentTime`, `startTime`, `endTime`, `isPlaying`, `speed`, optional `progressPercent`, `buffering`, `problems`. |
 | `TimelineApi` | Helpers aligned with the scrubber: `getTimeBounds`, `timeToPercent`, `percentToTime`. |
 | `MessageAccessApi` | Read-only `getMessagesInTimeRange` when the underlying player supports it. |
 
@@ -431,7 +431,8 @@ const annotationExtension: RosViewExtension = {
 ### Best practices
 
 - Prefer `playback.subscribeCurrentTime()` for high-frequency visuals (canvas/ref updates) instead of React setState on every frame.
-- Use `playback.getSnapshot()` for low-frequency state checks like `isPlaying`, `startTime`, and `endTime`.
+- Use `playback.getCurrentTime()` for one-off real-time playhead reads.
+- Use `playback.getSnapshot()` for low-frequency state checks like `isPlaying`, `startTime`, and `endTime`; its `currentTime` is a compatibility snapshot, not a React-driven playhead source.
 - Keep extension renderers resilient; runtime errors are isolated from core playback controls.
 
 ---
@@ -439,6 +440,8 @@ const annotationExtension: RosViewExtension = {
 ## MessagePipeline Hook
 
 For advanced use cases — subscribing to playback state and decoded messages from within custom React components rendered inside the viewer.
+
+`useMessagePipeline` is intended for slowly-changing metadata such as presence, topics, bounds, progress, speed, and decoded message availability. Do not use `playerState.activeData.currentTime` for live playback UI; use `playback.subscribeCurrentTime()` or `playback.getCurrentTime()` instead.
 
 ```ts
 import { useMessagePipeline } from '@ioai/rosview';

--- a/docs/API.zh.md
+++ b/docs/API.zh.md
@@ -370,8 +370,8 @@ import type {
 | `SidebarTabContribution` | 注册侧边栏 Tab（`id`、`title`、可选 `icon`、`order`、`render(context)`）。 |
 | `PlaybackOverlayContribution` | 在播放条上方注册一块区域（`id`、可选 `order`、`height`、`render(context)`）。 |
 | `RosViewExtensionContext` | 传给扩展渲染器的稳定上下文（含 `playback`、`timeline`、`messages`、`hostContext`）。 |
-| `PlaybackControlsApi` | 播放控制：`seek`、`play`、`pause`、`setSpeed`、`setLooping`、`stepBy`、`stepMessage`、`playUntil`、`subscribeCurrentTime`、`getSnapshot`。 |
-| `PlaybackSnapshot` | 播放状态快照；可含 `progressPercent`、`buffering`、`problems` 等。 |
+| `PlaybackControlsApi` | 播放控制：`seek`、`play`、`pause`、`setSpeed`、`setLooping`、`stepBy`、`stepMessage`、`playUntil`、`subscribeCurrentTime`、`getCurrentTime`、`getSnapshot`。 |
+| `PlaybackSnapshot` | 低频播放状态快照；包含 `currentTime`、`startTime`、`endTime`、`isPlaying`、`speed`，可含 `progressPercent`、`buffering`、`problems` 等。 |
 | `TimelineApi` | 与主 scrubber 对齐：`getTimeBounds`、`timeToPercent`、`percentToTime`。 |
 | `MessageAccessApi` | 只读 `getMessagesInTimeRange`（播放器支持时）。 |
 
@@ -417,7 +417,8 @@ const annotationExtension: RosViewExtension = {
 ### 最佳实践
 
 - 高频视觉更新优先用 `playback.subscribeCurrentTime()`，避免每帧 `setState`。
-- 低频状态检查（如 `isPlaying`、`startTime`、`endTime`）用 `playback.getSnapshot()`。
+- 一次性读取实时播放头时用 `playback.getCurrentTime()`。
+- 低频状态检查（如 `isPlaying`、`startTime`、`endTime`）用 `playback.getSnapshot()`；其中的 `currentTime` 是兼容快照，不适合作为 React 驱动的实时播放头来源。
 - 扩展渲染器应容错；运行时错误与核心播放控制隔离。
 
 ---
@@ -425,6 +426,8 @@ const annotationExtension: RosViewExtension = {
 ## MessagePipeline Hook
 
 高级用法：在查看器内嵌的自定义 React 组件中订阅播放状态与解码消息。
+
+`useMessagePipeline` 适合订阅低频元数据，例如 presence、topics、bounds、progress、speed 和解码消息可用性。实时播放 UI 不应依赖 `playerState.activeData.currentTime`；请使用 `playback.subscribeCurrentTime()` 或 `playback.getCurrentTime()`。
 
 ```ts
 import { useMessagePipeline } from '@ioai/rosview';

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -333,7 +333,8 @@ flowchart TB
     BufferedSource -->|"messageIterator\n(17ms batches)"| Player
     BlockLoader -->|"background prefill\ntime-block cache"| BufferedSource
 
-    Player -->|"PlayerState\n(messages, currentTime,\ntopics, progress)"| Pipeline
+    Player -->|"PlayerState\nmetadata, topics, progress"| Pipeline
+    Player -->|"subscribeCurrentTime()\ngetCurrentTime()"| FrameThrottle
     Pipeline --> FrameThrottle
     FrameThrottle -->|"messageEventsBySubscriberId"| ImagePanel
     FrameThrottle --> PlotPanel
@@ -408,10 +409,13 @@ Key design decisions:
 - **BlockLoader**: divides the entire file timeline into up to 400 blocks and preloads in the background
 - **Seek backfill**: when seeking to a target time, fetches the most recent message per subscribed topic so panels always have data to display
 - **Startup delay**: waits 100 ms after initialization before starting playback, giving panels time to call `setSubscriptions`
+- **Playback time channel**: high-frequency `currentTime` updates go through `subscribeCurrentTime()` / `getCurrentTime()` instead of the Zustand pipeline store
 
 #### MessagePipeline Layer
 
 Core message distribution pipeline (Zustand store + custom pub/sub):
+
+The Zustand store is intentionally limited to slowly-changing metadata. `PlayerState.activeData.currentTime` remains as a compatibility snapshot for discrete events such as initialization, seek, pause, loop/end boundaries, and close, but it is not updated for every playback tick.
 
 ```typescript
 interface MessagePipelineState {
@@ -443,7 +447,7 @@ Frame-rate control mechanism:
 1. Player pushes `PlayerState` via `setListener`
 2. The pipeline waits for all panels to call `renderDone` before processing the next frame
 3. `msPerFrame` enforces a minimum interval between frames
-4. Panels subscribe with `useMessagePipeline(selector)` to receive only the slice they need
+4. Panels subscribe with `useMessagePipeline(selector)` to receive only the slow metadata slice they need; live playhead UI uses `subscribeCurrentTime()` or `getCurrentTime()`
 
 #### Panel Layer
 
@@ -598,7 +602,12 @@ const subscribersRef = useRef<Set<(time: Time) => void>>(new Set());
 
 function subscribeCurrentTime(callback: (time: Time) => void) {
   subscribersRef.current.add(callback);
+  if (currentTimeRef.current) callback(currentTimeRef.current);
   return () => subscribersRef.current.delete(callback);
+}
+
+function getCurrentTime() {
+  return currentTimeRef.current;
 }
 
 // Advance playback without triggering React renders

--- a/docs/ARCHITECTURE.zh.md
+++ b/docs/ARCHITECTURE.zh.md
@@ -326,7 +326,8 @@ flowchart TB
     BufferedSource -->|"messageIterator\n(17ms 批量)"| Player
     BlockLoader -->|"后台预填充\n时间块缓存"| BufferedSource
 
-    Player -->|"PlayerState\n(messages, currentTime,\ntopics, progress)"| Pipeline
+    Player -->|"PlayerState\nmetadata, topics, progress"| Pipeline
+    Player -->|"subscribeCurrentTime()\ngetCurrentTime()"| FrameThrottle
     Pipeline --> FrameThrottle
     FrameThrottle -->|"messageEventsBySubscriberId"| ImagePanel
     FrameThrottle --> PlotPanel
@@ -403,10 +404,13 @@ interface Initialization {
 - **BlockLoader**：将整个文件时间线划分为最多 400 个 block，后台预加载
 - **Seek backfill**：跳转到目标时间时，为每个已订阅 Topic 获取最近一条消息（确保面板立即有数据显示）
 - **启动延迟**：初始化后等待 100ms 再开始播放，让面板先完成 `setSubscriptions`
+- **播放时间通道**：高频 `currentTime` 通过 `subscribeCurrentTime()` / `getCurrentTime()` 暴露，不经过 Zustand pipeline store
 
 #### MessagePipeline 层
 
 核心消息分发管线（Zustand store + 自定义发布/订阅）：
+
+Zustand store 只承载低频元数据。`PlayerState.activeData.currentTime` 作为兼容快照保留，只在初始化、seek、pause、loop/end 边界、close 等离散事件刷新，不会在播放 tick 中持续更新。
 
 ```typescript
 interface MessagePipelineState {
@@ -438,7 +442,7 @@ interface MessagePipelineState {
 1. Player 通过 `setListener` 推送 PlayerState
 2. Pipeline 收到后，必须等上一帧所有面板 `renderDone` 后才处理下一帧
 3. `msPerFrame` 限制两帧之间的最小间隔
-4. 面板通过 `useMessagePipeline(selector)` 只订阅需要的切片
+4. 面板通过 `useMessagePipeline(selector)` 只订阅需要的低频元数据切片；实时播放头使用 `subscribeCurrentTime()` 或 `getCurrentTime()`
 
 #### 面板层
 
@@ -596,7 +600,12 @@ const subscribersRef = useRef<Set<(time: Time) => void>>(new Set());
 
 function subscribeCurrentTime(callback: (time: Time) => void) {
   subscribersRef.current.add(callback);
+  if (currentTimeRef.current) callback(currentTimeRef.current);
   return () => subscribersRef.current.delete(callback);
+}
+
+function getCurrentTime() {
+  return currentTimeRef.current;
 }
 
 // 播放推进时直接调 subscriber（不触发 React 渲染）

--- a/src/core/extensions/buildContext.ts
+++ b/src/core/extensions/buildContext.ts
@@ -43,14 +43,17 @@ function timeToPercentInternal(current: Time, start: Time, end: Time): number {
   return clampPercent(Number((currentNano * 10000n) / total) / 100);
 }
 
-function buildPlaybackSnapshot(state: MessagePipelineState['playerState']): PlaybackSnapshot {
+function buildPlaybackSnapshot(
+  state: MessagePipelineState['playerState'],
+  currentTime: Time | undefined,
+): PlaybackSnapshot {
   const activeData = state.activeData;
   const pr = state.progress;
   return {
     presence: state.presence,
     startTime: activeData?.startTime,
     endTime: activeData?.endTime,
-    currentTime: activeData?.currentTime,
+    currentTime,
     isPlaying: activeData?.isPlaying ?? false,
     isLooping: activeData?.isLooping ?? true,
     speed: activeData?.speed ?? 1,
@@ -104,7 +107,7 @@ export function createPlaybackControlsApi(
     playUntil: (time) =>
       new Promise<void>((resolve) => {
         const targetNs = toNano(time);
-        const snap = buildPlaybackSnapshot(getPlayerState());
+        const snap = buildPlaybackSnapshot(getPlayerState(), player.getCurrentTime());
         const cur = snap.currentTime;
         if (cur && toNano(cur) >= targetNs) {
           resolve();
@@ -120,7 +123,8 @@ export function createPlaybackControlsApi(
         player.play();
       }),
     subscribeCurrentTime: (cb) => player.subscribeCurrentTime(cb),
-    getSnapshot: () => buildPlaybackSnapshot(getPlayerState()),
+    getCurrentTime: () => player.getCurrentTime(),
+    getSnapshot: () => buildPlaybackSnapshot(getPlayerState(), player.getCurrentTime()),
   };
 }
 

--- a/src/core/extensions/types.ts
+++ b/src/core/extensions/types.ts
@@ -39,6 +39,8 @@ export interface PlaybackControlsApi {
    */
   playUntil(time: Time): Promise<void>;
   subscribeCurrentTime(cb: (time: Time) => void): Unsubscribe;
+  /** Latest playback time without subscribing React to high-frequency pipeline state. */
+  getCurrentTime(): Time | undefined;
   getSnapshot(): PlaybackSnapshot;
 }
 

--- a/src/core/pipeline/store.ts
+++ b/src/core/pipeline/store.ts
@@ -20,7 +20,8 @@ const EMPTY_DATATYPES = {} as RosDatatypes;
  * Message state (lastMessageByTopic, per-subscriber batches, seq counters) is
  * kept out of this store and lives in `messageBus` with per-key subscriptions.
  * This store only holds slowly-changing metadata so that per-tick fan-out does
- * not wake every useMessagePipeline subscriber.
+ * not wake every useMessagePipeline subscriber. Real-time playback time is
+ * exposed through Player.subscribeCurrentTime/getCurrentTime instead.
  */
 export const useMessagePipelineStore = create<MessagePipelineState>((set) => ({
   playerState: { presence: 'preinit', progress: {} },
@@ -42,8 +43,8 @@ export const useMessagePipelineStore = create<MessagePipelineState>((set) => ({
       }
       // Re-use existing references when the underlying identity has not changed
       // so that selectors returning these fields are Object.is-equal and React
-      // skips the re-render, while still notifying selectors that depend on
-      // playerState itself (e.g. currentTime via activeData).
+      // skips the re-render for selectors that do not depend on playerState
+      // identity itself.
       return {
         playerState,
         sortedTopics: ad.topics === state.sortedTopics ? state.sortedTopics : ad.topics,

--- a/src/core/players/IterablePlayer.test.ts
+++ b/src/core/players/IterablePlayer.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { IterablePlayer } from './IterablePlayer';
 import { messageBus } from '@/core/pipeline/messageBus';
+import { useMessagePipelineStore } from '@/core/pipeline/store';
 import type { Initialization, MessageEvent } from '@/core/types/ros';
 import type { PlayerState } from '@/core/types/player';
 import type { WorkerSerializedSource } from '@/infra/workers/WorkerSerializedSource';
@@ -264,6 +265,75 @@ describe('IterablePlayer playback clock', () => {
 
     unsubscribe();
     player.close();
+  });
+
+  it('returns current time through the imperative getter', async () => {
+    const source = makeSource([]);
+    const player = new IterablePlayer(source);
+
+    await player.initialize({});
+    expect(player.getCurrentTime()).toEqual({ sec: 0, nsec: 0 });
+
+    player.seek({ sec: 3, nsec: 250_000_000 });
+    await flushAsyncWork();
+    expect(player.getCurrentTime()).toEqual({ sec: 3, nsec: 250_000_000 });
+
+    player.close();
+  });
+
+  it('does not advance pipeline-store currentTime on pure playback ticks', async () => {
+    let now = 0;
+    let nextRafId = 1;
+    const oldPerformanceNow = performance.now;
+    const oldRequestAnimationFrame = globalThis.requestAnimationFrame;
+    const oldCancelAnimationFrame = globalThis.cancelAnimationFrame;
+    const rafCallbacks = new Map<number, FrameRequestCallback>();
+    Object.defineProperty(performance, 'now', {
+      configurable: true,
+      value: () => now,
+    });
+    globalThis.requestAnimationFrame = vi.fn((cb: FrameRequestCallback) => {
+      const id = nextRafId++;
+      rafCallbacks.set(id, cb);
+      return id;
+    });
+    globalThis.cancelAnimationFrame = vi.fn((id: number) => {
+      rafCallbacks.delete(id);
+    });
+
+    const source = makeSource([]);
+    const player = new IterablePlayer(source);
+    const seenTimes: number[] = [];
+
+    try {
+      await player.initialize({});
+      player.play();
+      const pipelineTimeBefore = useMessagePipelineStore.getState().playerState.activeData?.currentTime;
+      const unsubscribeTime = player.subscribeCurrentTime((time) => {
+        seenTimes.push(time.sec + time.nsec / 1e9);
+      });
+
+      now = 1000;
+      const firstRaf = Math.min(...rafCallbacks.keys());
+      rafCallbacks.get(firstRaf)?.(now);
+      await flushAsyncWork();
+
+      expect(seenTimes.at(-1)).toBeCloseTo(1, 3);
+      expect(player.getCurrentTime()).toEqual({ sec: 1, nsec: 0 });
+      expect(useMessagePipelineStore.getState().playerState.activeData?.currentTime).toBe(
+        pipelineTimeBefore,
+      );
+
+      unsubscribeTime();
+    } finally {
+      player.close();
+      Object.defineProperty(performance, 'now', {
+        configurable: true,
+        value: oldPerformanceNow,
+      });
+      globalThis.requestAnimationFrame = oldRequestAnimationFrame;
+      globalThis.cancelAnimationFrame = oldCancelAnimationFrame;
+    }
   });
 
   it('does not catch up wall time elapsed while the page is hidden', async () => {

--- a/src/core/players/IterablePlayer.ts
+++ b/src/core/players/IterablePlayer.ts
@@ -67,6 +67,16 @@ function isSameTimeRanges(nextValue?: TimeRange[], prevValue?: TimeRange[]): boo
   return true;
 }
 
+function isSameTime(nextValue: Time | undefined, prevValue: Time | undefined): boolean {
+  if (nextValue === prevValue) {
+    return true;
+  }
+  if (!nextValue || !prevValue) {
+    return false;
+  }
+  return nextValue.sec === prevValue.sec && nextValue.nsec === prevValue.nsec;
+}
+
 type SharedPayloadRingProgress = NonNullable<PlayerState["progress"]["sharedPayloadRing"]>;
 
 function isSameSharedPayloadRing(
@@ -176,6 +186,10 @@ export class IterablePlayer implements Player {
     return () => {
       this._timeSubscribers.delete(cb);
     };
+  }
+
+  getCurrentTime(): Time | undefined {
+    return this._state.presence === "closed" ? undefined : this._currentTime;
   }
 
   registerSubscriptions(panelId: string, subscriptions: Subscription[]): void {
@@ -661,29 +675,46 @@ export class IterablePlayer implements Player {
     }
   }
 
-  /** Replace activeData with a shallow copy so Zustand/React see a new reference. */
-  private _syncActiveDataSlice(): void {
+  /**
+   * Replace activeData only when slow metadata changes.
+   *
+   * Playback time itself is high-frequency and is delivered through
+   * subscribeCurrentTime/getCurrentTime. Keeping it out of the periodic pipeline
+   * emit prevents every useMessagePipeline selector from waking during playback.
+   */
+  private _syncActiveDataSlice(options: { includeCurrentTime?: boolean } = {}): boolean {
     const cur = this._state.activeData;
-    if (!cur) return;
+    if (!cur) return false;
+    const nextCurrentTime = options.includeCurrentTime === true ? this._currentTime : cur.currentTime;
+    const unchanged =
+      isSameTime(cur.currentTime, nextCurrentTime) &&
+      cur.isPlaying === this._isPlaying &&
+      cur.isLooping === this._isLooping &&
+      cur.speed === this._speed;
+    if (unchanged) {
+      return false;
+    }
     this._state.activeData = {
       ...cur,
-      currentTime: this._currentTime,
+      currentTime: nextCurrentTime,
       isPlaying: this._isPlaying,
       isLooping: this._isLooping,
       speed: this._speed,
     };
+    return true;
   }
 
   private _maybeEmitPipelineState(): void {
     const now = performance.now();
     if (now - this._lastPipelineEmitMs < PIPELINE_EMIT_INTERVAL_MS) return;
     this._lastPipelineEmitMs = now;
-    this._syncActiveDataSlice();
-    useMessagePipelineStore.getState().setPlayerState(this._state);
+    if (this._syncActiveDataSlice({ includeCurrentTime: false })) {
+      useMessagePipelineStore.getState().setPlayerState(this._state);
+    }
   }
 
   private _emitState() {
-    this._syncActiveDataSlice();
+    this._syncActiveDataSlice({ includeCurrentTime: true });
 
     if (this._listener) {
       this._listener(this._state);

--- a/src/core/players/MinimalPlayer.test.ts
+++ b/src/core/players/MinimalPlayer.test.ts
@@ -27,6 +27,11 @@ describe('MinimalPlayer', () => {
     unsub();
   });
 
+  it('getCurrentTime returns the latest zero time while ready', () => {
+    player = new MinimalPlayer();
+    expect(player.getCurrentTime()).toEqual({ sec: 0, nsec: 0 });
+  });
+
   it('close sets presence to closed', () => {
     player = new MinimalPlayer();
     player.close();

--- a/src/core/players/MinimalPlayer.ts
+++ b/src/core/players/MinimalPlayer.ts
@@ -68,6 +68,10 @@ export class MinimalPlayer implements Player {
     };
   }
 
+  getCurrentTime(): Time | undefined {
+    return this._currentTime();
+  }
+
   play(): void {}
 
   pause(): void {}

--- a/src/core/types/player.ts
+++ b/src/core/types/player.ts
@@ -102,6 +102,8 @@ export interface Player {
   unregisterHighFrequencyConsumer(consumerId: string): void;
   /** Playback time updates without going through React state (rAF path). Immediately emits the current time. */
   subscribeCurrentTime(cb: (time: Time) => void): Unsubscribe;
+  /** Latest playback time. Prefer this or subscribeCurrentTime for real-time playhead reads. */
+  getCurrentTime(): Time | undefined;
   play(): void;
   pause(): void;
   seek(time: Time): void;

--- a/src/features/extensions/PlaybackOverlayHost.tsx
+++ b/src/features/extensions/PlaybackOverlayHost.tsx
@@ -32,6 +32,25 @@ function sortByOrder(a: { order?: number }, b: { order?: number }): number {
   return (a.order ?? 0) - (b.order ?? 0);
 }
 
+const PlaybackOverlayItem = React.memo(function PlaybackOverlayItem({
+  overlay,
+  context,
+}: {
+  overlay: PlaybackOverlayContribution;
+  context: RosViewExtensionContext;
+}) {
+  return (
+    <ExtensionRenderBoundary extensionId={overlay.id}>
+      <div
+        data-testid={`playback-overlay-${overlay.id}`}
+        style={overlay.height == undefined ? undefined : { height: overlay.height }}
+      >
+        {overlay.render(context)}
+      </div>
+    </ExtensionRenderBoundary>
+  );
+});
+
 export const PlaybackOverlayHost: React.FC<PlaybackOverlayHostProps> = ({ overlays, context }) => {
   const ordered = React.useMemo(() => [...(overlays ?? [])].sort(sortByOrder), [overlays]);
   if (ordered.length === 0) {
@@ -40,14 +59,7 @@ export const PlaybackOverlayHost: React.FC<PlaybackOverlayHostProps> = ({ overla
   return (
     <>
       {ordered.map((overlay) => (
-        <ExtensionRenderBoundary key={overlay.id} extensionId={overlay.id}>
-          <div
-            data-testid={`playback-overlay-${overlay.id}`}
-            style={overlay.height == undefined ? undefined : { height: overlay.height }}
-          >
-            {overlay.render(context)}
-          </div>
-        </ExtensionRenderBoundary>
+        <PlaybackOverlayItem key={overlay.id} overlay={overlay} context={context} />
       ))}
     </>
   );

--- a/src/features/extensions/SidebarExtensionHost.tsx
+++ b/src/features/extensions/SidebarExtensionHost.tsx
@@ -25,12 +25,24 @@ class ExtensionRenderBoundary extends React.Component<{ extensionId: string; chi
   }
 }
 
-export const SidebarExtensionHost: React.FC<SidebarExtensionHostProps> = ({ contribution, context }) => {
+const SidebarExtensionContent = React.memo(function SidebarExtensionContent({
+  contribution,
+  context,
+}: SidebarExtensionHostProps) {
+  return (
+    <div className="flex min-h-0 min-w-0 w-full flex-1 flex-col overflow-hidden">
+      {contribution.render(context)}
+    </div>
+  );
+});
+
+export const SidebarExtensionHost: React.FC<SidebarExtensionHostProps> = React.memo(function SidebarExtensionHost({
+  contribution,
+  context,
+}) {
   return (
     <ExtensionRenderBoundary extensionId={contribution.id}>
-      <div className="flex min-h-0 min-w-0 w-full flex-1 flex-col overflow-hidden">
-        {contribution.render(context)}
-      </div>
+      <SidebarExtensionContent contribution={contribution} context={context} />
     </ExtensionRenderBoundary>
   );
-};
+});

--- a/src/features/panels/Align/Component.tsx
+++ b/src/features/panels/Align/Component.tsx
@@ -40,24 +40,16 @@ export const AlignPanel: React.FC<AlignPanelProps> = (props) => {
   const { player, panelId, setConfig, topics: configTopics, timeMode, windowHalfMs, dotRadius, dotOpacity } = props;
   const { formatMessage } = useIntl();
 
-  const { sortedTopics, startTime, endTime, storeCurrentTime } = useMessagePipeline(
+  const { sortedTopics, startTime, endTime } = useMessagePipeline(
     useShallow((state: MessagePipelineState) => ({
       sortedTopics: state.sortedTopics,
       startTime: state.playerState.activeData?.startTime,
       endTime: state.playerState.activeData?.endTime,
-      storeCurrentTime: state.playerState.activeData?.currentTime,
     })),
   );
 
-  const centerTimeRef = useRef<Time>({ sec: 0, nsec: 0 });
+  const centerTimeRef = useRef<Time>(player.getCurrentTime() ?? { sec: 0, nsec: 0 });
   const [centerTick, setCenterTick] = useState(0);
-
-  useEffect(() => {
-    if (storeCurrentTime) {
-      centerTimeRef.current = storeCurrentTime;
-      setCenterTick((v) => v + 1);
-    }
-  }, [storeCurrentTime]);
 
   const imageTopicNames = useMemo(
     () => sortedTopics.filter((t) => isRosImageSchema(t.type)).map((t) => t.name),

--- a/src/features/workspace/playback/PlaybackBar.tsx
+++ b/src/features/workspace/playback/PlaybackBar.tsx
@@ -162,7 +162,7 @@ export const PlaybackBar: React.FC<PlaybackBarProps> = ({ player, extensionConte
 
   const startTimeRef = useRef<Time | undefined>(undefined);
   const endTimeRef = useRef<Time | undefined>(undefined);
-  const latestTimeRef = useRef<Time | undefined>(undefined);
+  const latestTimeRef = useRef<Time | undefined>(player.getCurrentTime());
   const isDraggingRef = useRef(false);
   const lastHoverPercentRef = useRef<number | null>(null);
   const cancelPlaybackFrameRef = useRef<(() => void) | null>(null);


### PR DESCRIPTION
## Description

This PR separates **high-frequency playhead updates** from the **low-frequency Zustand pipeline store**, reducing React re-render pressure during MCAP playback.

### Playback time channel

- Add `Player.getCurrentTime()` and `PlaybackControlsApi.getCurrentTime()` for imperative, real-time playhead reads.
- `IterablePlayer` no longer writes `activeData.currentTime` on every playback tick into `useMessagePipelineStore`.
- **Discrete events** (init, seek, pause, loop/end, close) still refresh `activeData.currentTime` via `_emitState()`.
- **Periodic pipeline emits** (`_maybeEmitPipelineState`, 200 ms) skip updates when only time would change; they still propagate slow metadata (`isPlaying`, `speed`, progress, etc.).

### Call-site updates

- `PlaybackBar`: initialize playhead ref from `player.getCurrentTime()`.
- `AlignPanel`: follow playhead via `subscribeCurrentTime()` instead of `useMessagePipeline` `currentTime`.
- Extension context: `getSnapshot()` still includes `currentTime` as a **compatibility snapshot**, built from `getCurrentTime()` at read time.

### Render isolation

- `PlaybackOverlayHost`: memoize per-overlay items so extension subtree re-renders are bounded.
- `SidebarExtensionHost`: memoize host + content wrapper.

### Documentation

- `API.md` / `API.zh.md`: document `getCurrentTime()`, clarify high- vs low-frequency playback APIs.
- `ARCHITECTURE.md` / `ARCHITECTURE.zh.md`: document the dual-channel model (pipeline store vs `subscribeCurrentTime` / `getCurrentTime`).

## Motivation / related issue

During Studio playback, `useMessagePipeline` subscribers were waking on every tick because `activeData.currentTime` changed continuously in the Zustand store. That drove unnecessary React reconciliation (~110 scheduler tasks/s in traces) even for components that only needed slow metadata (bounds, `isPlaying`, progress).

This change keeps the pipeline store for **slowly changing metadata** and routes the playhead through **`subscribeCurrentTime()` / `getCurrentTime()`**, matching the pattern already used by 3D/Image panels.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [x] Documentation update
- [x] Refactor / internal cleanup (no behavior change)

## Checklist

- [x] `npm run lint` passes with no errors
- [x] `npm test` passes (unit tests)
- [x] `npm run build` and `npm run build:lib` succeed
- [x] New behavior is covered by tests (or explain why tests aren't applicable)
- [x] Documentation updated (README, API.md, EMBEDDING.md) if the public API changed
- [ ] **Breaking change**: all affected call sites updated and migration path described in PR description

## API compatibility

**Additive, non-breaking**

| Symbol | Change |
|--------|--------|
| `Player.getCurrentTime()` | **New** — returns latest playhead time without subscribing |
| `PlaybackControlsApi.getCurrentTime()` | **New** — same, exposed on extension context |
| `PlaybackControlsApi.getSnapshot()` | **Unchanged signature** — `currentTime` is now a point-in-time snapshot, not tick-driven |
| `Player.subscribeCurrentTime()` | **Unchanged** — still the preferred high-frequency channel |

**Migration for embedders / extensions**

- **Do not** drive per-frame UI from `getSnapshot().currentTime` or `useMessagePipeline(s => s.playerState.activeData?.currentTime)`.
- **Do** use `subscribeCurrentTime()` (refs, canvas, throttled listeners) or `getCurrentTime()` for one-off reads.
- **Keep** `useMessagePipeline` for slow metadata: presence, topics, bounds, progress, `isPlaying`, speed.

No exports removed.

## Test plan

- [x] `IterablePlayer`: `getCurrentTime()` reflects seek/playhead; pipeline store `currentTime` does **not** advance on pure playback ticks
- [x] `MinimalPlayer`: `getCurrentTime()` returns zero time while ready
- [ ] Manual: open Studio, play MCAP — scrubber/playhead updates smoothly; extensions (marker overlay) remain responsive
- [ ] Manual: seek / pause / loop — `getSnapshot().currentTime` and pipeline store still update on discrete events

## Screenshots / recordings

N/A — performance-oriented internal change; no intentional visible UI change. Optional: before/after Performance trace comparing `performWorkUntilDeadline` rate during playback.