### PR TITLE
feat: loading ux v1.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ioai/rosview",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ioai/rosview",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ioai/rosview",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "High-performance robotics data visualization for MCAP, ROS bag, ROS2 db3, HDF5 and BVH — embeddable React component and standalone SPA",
   "keywords": [
     "ros",

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -42,6 +42,7 @@ interface AppShellProps {
   onSubmitRemoteUrl: (url: string) => void | Promise<void>;
   remoteSubmitLoading?: boolean;
   onSelectSample: (sample: SampleDataset) => void | Promise<void>;
+  onCancelLoading?: () => void;
   historyItems: DatasetHistoryListItem[];
   onReplayHistory: (id: string) => void | Promise<void>;
   onDropRosRecordingFiles: (files: File[], items?: DataTransferItemList) => void | Promise<void>;
@@ -91,6 +92,7 @@ export const AppShell: React.FC<AppShellProps> = ({
   onSubmitRemoteUrl,
   remoteSubmitLoading,
   onSelectSample,
+  onCancelLoading,
   historyItems,
   onReplayHistory,
   onDropRosRecordingFiles,
@@ -175,7 +177,7 @@ export const AppShell: React.FC<AppShellProps> = ({
         onSubmitRemoteUrl={onSubmitRemoteUrl}
         remoteSubmitLoading={remoteSubmitLoading}
         onSelectSample={onSelectSample}
-        onRequestChangeRemoteUrl={onOpenRemotePrompt}
+        onCancelLoading={onCancelLoading}
         historyItems={historyItems}
         onReplayHistory={onReplayHistory}
         onDropRosRecordingFiles={onDropRosRecordingFiles}

--- a/src/features/viewer/RosViewContent.tsx
+++ b/src/features/viewer/RosViewContent.tsx
@@ -13,12 +13,14 @@ import {
 import { openRawMessagesPanel } from '@/features/workspace/sidebar/topic-list/openRawMessagesPanel';
 import { useIntl } from 'react-intl';
 import { WelcomeScreen } from '@/features/workspace/common/WelcomeScreen';
+import { LoadingOverlay } from '@/features/workspace/common/LoadingOverlay';
 import { useMessagePipeline } from '@/core/pipeline/useMessagePipeline';
 import type { MessagePipelineState } from '@/core/pipeline/store';
 import { useMessagePipelineStore } from '@/core/pipeline/store';
 import type { SampleDataset } from '@/services/sampleDatasets';
 import type { DatasetHistoryListItem } from '@/shared/utils/datasetHistory';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/shared/ui/resizable';
+import { Skeleton } from '@/shared/ui/skeleton';
 import type { RosViewExtension } from '@/core/extensions/types';
 import { buildExtensionContext } from '@/core/extensions/buildContext';
 import type { FoxgloveLayoutData } from '@/core/preferences/foxgloveLayout';
@@ -49,7 +51,7 @@ interface RosViewContentProps {
   onSubmitRemoteUrl: (url: string) => void | Promise<void>;
   remoteSubmitLoading?: boolean;
   onSelectSample: (sample: SampleDataset) => void | Promise<void>;
-  onRequestChangeRemoteUrl?: () => void;
+  onCancelLoading?: () => void;
   historyItems: DatasetHistoryListItem[];
   onReplayHistory: (id: string) => void | Promise<void>;
   onDropRosRecordingFiles: (files: File[], items?: DataTransferItemList) => void | Promise<void>;
@@ -89,7 +91,7 @@ export const RosViewContent: React.FC<RosViewContentProps> = ({
   onSubmitRemoteUrl,
   remoteSubmitLoading,
   onSelectSample,
-  onRequestChangeRemoteUrl,
+  onCancelLoading,
   historyItems,
   onReplayHistory,
   onDropRosRecordingFiles,
@@ -112,8 +114,8 @@ export const RosViewContent: React.FC<RosViewContentProps> = ({
   const { formatMessage } = useIntl();
   const presence = useMessagePipeline((state: MessagePipelineState) => state.playerState.presence);
   const sortedTopics = useMessagePipeline((state: MessagePipelineState) => state.sortedTopics);
-  const isLoading = presence === 'initializing';
   const isReady = presence === 'ready';
+  const showWelcomeFallback = !isReady && Boolean(manualOpenHint);
   const topicDragDepthRef = useRef(0);
   const [sidebarPanelPercent, setSidebarPanelPercent] = useState(() =>
     getInitialSidebarPanelPercent(preferencePersistence),
@@ -251,11 +253,9 @@ export const RosViewContent: React.FC<RosViewContentProps> = ({
 
   return (
     <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
-      {!isReady ? (
+      {showWelcomeFallback ? (
         <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
           <WelcomeScreen
-            isLoading={isLoading}
-            loadingSourceName={loadingSourceName}
             manualOpenHint={manualOpenHint}
             onOpenFile={onOpenFilePick}
             onOpenDirectory={onOpenDirectory}
@@ -263,7 +263,6 @@ export const RosViewContent: React.FC<RosViewContentProps> = ({
             onSubmitRemoteUrl={onSubmitRemoteUrl}
             remoteSubmitLoading={remoteSubmitLoading}
             onSelectSample={onSelectSample}
-            onRequestChangeRemoteUrl={onRequestChangeRemoteUrl}
             historyItems={historyItems}
             onReplayHistory={onReplayHistory}
           />
@@ -334,10 +333,10 @@ export const RosViewContent: React.FC<RosViewContentProps> = ({
                 className={`relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background [contain:strict] ${
                   isTopicDragOver ? 'ring-1 ring-inset ring-primary/40' : ''
                 }`}
-                onDragEnter={handleTopicDragEnter}
-                onDragOver={handleMainDragOver}
-                onDragLeave={handleTopicDragLeave}
-                onDrop={handleMainDrop}
+                onDragEnter={isReady ? handleTopicDragEnter : undefined}
+                onDragOver={isReady ? handleMainDragOver : undefined}
+                onDragLeave={isReady ? handleTopicDragLeave : undefined}
+                onDrop={isReady ? handleMainDrop : undefined}
               >
                 {isTopicDragOver && (
                   <div className="pointer-events-none absolute inset-4 z-10 flex items-center justify-center rounded-lg border border-dashed border-primary/60 bg-primary/5">
@@ -351,17 +350,30 @@ export const RosViewContent: React.FC<RosViewContentProps> = ({
                     </div>
                   </div>
                 )}
-                <DockviewLayout
-                  key={activeDatasetId ?? 'dataset'}
-                  player={player}
-                  preferAutoLayout={preferAutoLayout}
-                  initialLayout={initialLayout}
-                  defaultPanel={defaultPanel}
-                  layoutPersistence={layoutPersistence}
-                  layoutStorageKey={layoutStorageKey}
-                  suppressWelcomePanel={suppressWelcomePanel}
-                  onLayoutReady={onLayoutReady}
-                />
+                {isReady ? (
+                  <DockviewLayout
+                    key={activeDatasetId ?? 'dataset'}
+                    player={player}
+                    preferAutoLayout={preferAutoLayout}
+                    initialLayout={initialLayout}
+                    defaultPanel={defaultPanel}
+                    layoutPersistence={layoutPersistence}
+                    layoutStorageKey={layoutStorageKey}
+                    suppressWelcomePanel={suppressWelcomePanel}
+                    onLayoutReady={onLayoutReady}
+                  />
+                ) : (
+                  <div className="flex min-h-0 flex-1 flex-col gap-3 p-4">
+                    <Skeleton className="h-8 w-40" />
+                    <Skeleton className="min-h-0 flex-1 rounded-lg" />
+                  </div>
+                )}
+                {!isReady ? (
+                  <LoadingOverlay
+                    sourceName={loadingSourceName}
+                    onCancel={onCancelLoading}
+                  />
+                ) : null}
               </main>
             </ResizablePanel>
           </ResizablePanelGroup>

--- a/src/features/viewer/RosViewerImpl.tsx
+++ b/src/features/viewer/RosViewerImpl.tsx
@@ -7,13 +7,15 @@ import { SampleDatasetDialog } from '@/features/workspace/common/SampleDatasetDi
 import { getArchiveUrl, getSampleDatasetsManifestUrl, loadSampleDatasets } from '@/services/sampleDatasets';
 import type { SampleDataset } from '@/services/sampleDatasets';
 import { extractRosFilesFromTarArchive } from '@/shared/utils/tarRosRecordings';
-import { WorkerSerializedSource } from '@/infra/workers/WorkerSerializedSource';
+import { WorkerSerializedSource, isWorkerSourceCancelledError } from '@/infra/workers/WorkerSerializedSource';
 import { IterablePlayer } from '@/core/players/IterablePlayer';
 import { MinimalPlayer } from '@/core/players/MinimalPlayer';
 import type { Player } from '@/core/types/player';
 import { useMessagePipelineStore } from '@/core/pipeline/store';
 import { Navbar } from '@/features/workspace/navbar/Navbar';
 import { WelcomeScreen } from '@/features/workspace/common/WelcomeScreen';
+import { LoadingOverlay } from '@/features/workspace/common/LoadingOverlay';
+import { Skeleton } from '@/shared/ui/skeleton';
 import type { DatasetItem, FileListItem } from '@/shared/utils/datasetSources';
 import {
   datasetItemsFromListItems,
@@ -771,6 +773,11 @@ export const RosViewer: React.FC<RosViewerProps> = (props) => {
           }
           return;
         } catch (err) {
+          if (cancelled || isWorkerSourceCancelledError(err)) {
+            newPlayer.close();
+            createdPlayer = null;
+            return;
+          }
           lastErr = err;
           newPlayer.close();
           createdPlayer = null;
@@ -1166,6 +1173,7 @@ export const RosViewer: React.FC<RosViewerProps> = (props) => {
       onSubmitRemoteUrl={handleOpenRemoteRecordingUrl}
       remoteSubmitLoading={remoteUrlBusy}
       onSelectSample={handleSelectSample}
+      onCancelLoading={handleGoHome}
       historyItems={historyItems}
       onReplayHistory={(id) => void handleReplayHistory(id)}
       onDropRosRecordingFiles={handleDropRosRecordingFiles}
@@ -1326,23 +1334,33 @@ export const RosViewer: React.FC<RosViewerProps> = (props) => {
               recentHistoryItems={historyItems.slice(0, 10)}
               onReplayHistory={(id) => void handleReplayHistory(id)}
             />
-            <WelcomeScreen
-              isLoading={!lastLoadError && !manualOpenHint}
-              loadingSourceName={loadingSourceName}
-              manualOpenHint={manualOpenHint}
-              onOpenFile={() => {
-                clearOpenFeedback();
-                void handleOpenRecordingFiles();
-              }}
-              onOpenDirectory={handleOpenDirectory}
-              onOpenTarPicker={() => document.getElementById('rosview-inline-tar')?.click()}
-              onSubmitRemoteUrl={handleOpenRemoteRecordingUrl}
-              remoteSubmitLoading={remoteUrlBusy}
-              onSelectSample={handleSelectSample}
-              onRequestChangeRemoteUrl={openRemotePrompt}
-              historyItems={historyItems}
-              onReplayHistory={(id) => void handleReplayHistory(id)}
-            />
+            {!lastLoadError && !manualOpenHint ? (
+              <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+                <div className="flex min-h-0 flex-1 flex-col gap-3 p-4">
+                  <Skeleton className="h-8 w-40" />
+                  <Skeleton className="min-h-0 flex-1 rounded-lg" />
+                </div>
+                <LoadingOverlay
+                  sourceName={loadingSourceName}
+                  onCancel={handleGoHome}
+                />
+              </div>
+            ) : (
+              <WelcomeScreen
+                manualOpenHint={manualOpenHint}
+                onOpenFile={() => {
+                  clearOpenFeedback();
+                  void handleOpenRecordingFiles();
+                }}
+                onOpenDirectory={handleOpenDirectory}
+                onOpenTarPicker={() => document.getElementById('rosview-inline-tar')?.click()}
+                onSubmitRemoteUrl={handleOpenRemoteRecordingUrl}
+                remoteSubmitLoading={remoteUrlBusy}
+                onSelectSample={handleSelectSample}
+                historyItems={historyItems}
+                onReplayHistory={(id) => void handleReplayHistory(id)}
+              />
+            )}
             <SampleDatasetDialog
               open={sampleDialogOpen}
               onOpenChange={setSampleDialogOpen}

--- a/src/features/workspace/common/LoadingOverlay.tsx
+++ b/src/features/workspace/common/LoadingOverlay.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { useIntl } from 'react-intl';
+import { Button } from '@/shared/ui/button';
+import { Card, CardFooter, CardHeader, CardTitle } from '@/shared/ui/card';
+import { Spinner } from '@/shared/ui/spinner';
+
+interface LoadingOverlayProps {
+  sourceName?: string;
+  onCancel?: () => void;
+}
+
+export const LoadingOverlay: React.FC<LoadingOverlayProps> = ({ sourceName, onCancel }) => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <div
+      className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center bg-background/50"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      <Card className="pointer-events-auto w-full max-w-sm border-border shadow-none">
+        <CardHeader className="gap-2 pb-4 text-center">
+          <Spinner className="mx-auto size-8 text-primary" aria-hidden />
+          <CardTitle className="text-base font-semibold tracking-tight">
+            {formatMessage({ id: 'welcome.loadingTitle' })}
+          </CardTitle>
+          {sourceName ? (
+            <p className="truncate text-xs text-muted-foreground" title={sourceName}>
+              {sourceName}
+            </p>
+          ) : null}
+          <p className="text-xs text-muted-foreground">
+            {formatMessage({ id: 'welcome.loadingPhase.preparing' })}
+          </p>
+        </CardHeader>
+        {onCancel ? (
+          <CardFooter className="justify-center pt-0">
+            <Button type="button" variant="outline" size="sm" onClick={onCancel}>
+              {formatMessage({ id: 'welcome.cancelLoading' })}
+            </Button>
+          </CardFooter>
+        ) : null}
+      </Card>
+    </div>
+  );
+};

--- a/src/features/workspace/common/WelcomeScreen.tsx
+++ b/src/features/workspace/common/WelcomeScreen.tsx
@@ -1,18 +1,13 @@
 import React from 'react';
-import { Link2 } from 'lucide-react';
 import { useIntl } from 'react-intl';
 import type { SampleDataset } from '@/services/sampleDatasets';
 import type { DatasetHistoryListItem } from '@/shared/utils/datasetHistory';
 import { useSampleDatasets } from '@/hooks/useSampleDatasets';
 import { DatasetSourceSelector } from '@/features/workspace/welcome/DatasetSourceSelector';
 import { SampleDatasetList } from '@/features/workspace/welcome/SampleDatasetList';
-import { Button } from '@/shared/ui/button';
 import { Separator } from '@/shared/ui/separator';
-import { Spinner } from '@/shared/ui/spinner';
 
 interface WelcomeScreenProps {
-  isLoading?: boolean;
-  loadingSourceName?: string;
   manualOpenHint?: string | null;
   onOpenFile: () => void;
   onOpenDirectory: () => void;
@@ -20,14 +15,11 @@ interface WelcomeScreenProps {
   onSubmitRemoteUrl: (url: string) => void | Promise<void>;
   remoteSubmitLoading?: boolean;
   onSelectSample: (sample: SampleDataset) => void | Promise<void>;
-  onRequestChangeRemoteUrl?: () => void;
   historyItems?: DatasetHistoryListItem[];
   onReplayHistory?: (id: string) => void | Promise<void>;
 }
 
 export const WelcomeScreen: React.FC<WelcomeScreenProps> = ({
-  isLoading,
-  loadingSourceName,
   manualOpenHint,
   onOpenFile,
   onOpenDirectory,
@@ -35,7 +27,6 @@ export const WelcomeScreen: React.FC<WelcomeScreenProps> = ({
   onSubmitRemoteUrl,
   remoteSubmitLoading,
   onSelectSample,
-  onRequestChangeRemoteUrl,
   historyItems = [],
   onReplayHistory,
 }) => {
@@ -44,31 +35,6 @@ export const WelcomeScreen: React.FC<WelcomeScreenProps> = ({
   const hasSamples = samples.length > 0;
   /** Show samples column while loading or when any samples exist; hide when none configured after load. */
   const showSamplesSection = samplesLoading || hasSamples;
-
-  if (isLoading) {
-    return (
-      <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-8 bg-background px-6 py-16">
-        <div className="w-full max-w-sm rounded-xl border border-border bg-card px-8 py-12 text-center shadow-sm">
-          <Spinner className="mx-auto mb-5 size-10 text-primary" aria-hidden />
-          <h2 className="text-lg font-semibold tracking-tight text-foreground">
-            {formatMessage({ id: 'welcome.loadingTitle' })}
-          </h2>
-          {loadingSourceName ? (
-            <p className="mx-auto mt-3 max-w-full truncate text-xs text-muted-foreground" title={loadingSourceName}>
-              {loadingSourceName}
-            </p>
-          ) : null}
-          <p className="mt-4 text-sm text-muted-foreground">{formatMessage({ id: 'welcome.loadingHint' })}</p>
-        </div>
-        {onRequestChangeRemoteUrl ? (
-          <Button type="button" variant="link" className="text-sm" onClick={onRequestChangeRemoteUrl}>
-            <Link2 data-icon="inline-start" aria-hidden />
-            {formatMessage({ id: 'welcome.changeUrl' })}
-          </Button>
-        ) : null}
-      </div>
-    );
-  }
 
   return (
     <div className="relative flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden bg-background">

--- a/src/features/workspace/sidebar/Sidebar.tsx
+++ b/src/features/workspace/sidebar/Sidebar.tsx
@@ -6,6 +6,7 @@ import type { MessagePipelineState } from '@/core/pipeline/store';
 import type { Player } from '@/core/types/player';
 import type { TopicInfo } from '@/core/types/ros';
 import { ScrollArea } from '@/shared/ui/scroll-area';
+import { Skeleton } from '@/shared/ui/skeleton';
 import { AlertTriangle, Database, Layers, Search, Settings2 } from 'lucide-react';
 import { useSidebarStore } from '@/shared/hooks/useSidebarStore';
 import { PanelSettingsTab } from './PanelSettingsTab';
@@ -21,6 +22,20 @@ import { cn } from '@/shared/lib/utils';
 
 const SIDEBAR_TAB_TRIGGER_CLASS =
   'flex flex-1 items-center justify-center gap-1 border-b-2 border-transparent px-2 py-2 text-xs font-medium transition-colors hover:bg-accent/70 data-[state=active]:border-primary data-[state=active]:bg-background data-[state=active]:text-primary';
+
+const TOPIC_LIST_SKELETON_ROWS = 8;
+
+function TopicRowSkeleton(): React.ReactElement {
+  return (
+    <div className="flex w-full items-start gap-3 border-b border-border/50 p-2">
+      <div className="min-w-0 flex-1 flex flex-col gap-1">
+        <Skeleton className="h-4 w-[75%]" />
+        <Skeleton className="h-3 w-[55%]" />
+      </div>
+      <Skeleton className="h-4 w-10 shrink-0" />
+    </div>
+  );
+}
 
 interface SidebarProps {
   player: Player;
@@ -50,6 +65,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
 }) => {
   const { formatMessage } = useIntl();
   const topics = useMessagePipeline((state: MessagePipelineState) => state.sortedTopics);
+  const playerPresence = useMessagePipeline((state: MessagePipelineState) => state.playerState.presence);
+  const topicsLoading = playerPresence === 'preinit' || playerPresence === 'initializing';
   const activeTab = useSidebarStore((s) => s.tab);
   const setActiveTab = useSidebarStore((s) => s.setTab);
   const initialSidebarTabAppliedRef = useRef(false);
@@ -189,7 +206,11 @@ export const Sidebar: React.FC<SidebarProps> = ({
           </div>
           <ScrollArea className="flex-1 min-h-0">
             <div className="border-b border-border/50">
-              {filteredTopics.length > 0 ? (
+              {topicsLoading ? (
+                Array.from({ length: TOPIC_LIST_SKELETON_ROWS }, (_, index) => (
+                  <TopicRowSkeleton key={index} />
+                ))
+              ) : filteredTopics.length > 0 ? (
                 filteredTopics.map((topic: TopicInfo) => (
                   <TopicRow
                     key={topic.name}

--- a/src/infra/workers/WorkerSerializedSource.test.ts
+++ b/src/infra/workers/WorkerSerializedSource.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Initialization } from '@/core/types/ros';
+import {
+  WorkerSerializedSource,
+  WorkerSourceCancelledError,
+} from './WorkerSerializedSource';
+
+const mockInitialization: Initialization = {
+  topics: [],
+  datatypes: new Map(),
+  start: { sec: 0, nsec: 0 },
+  end: { sec: 1, nsec: 0 },
+  publishersByTopic: {},
+  topicStats: {},
+  problems: [],
+};
+
+type MockRemote = {
+  initialize: ReturnType<typeof vi.fn>;
+  configureTransport: ReturnType<typeof vi.fn>;
+  getTransportDiagnostics: ReturnType<typeof vi.fn>;
+};
+
+let mockRemote: MockRemote;
+let workerListeners: Map<string, Set<EventListener>>;
+
+function createMockWorker(): Worker {
+  workerListeners = new Map();
+  return {
+    addEventListener(type: string, listener: EventListener) {
+      let set = workerListeners.get(type);
+      if (!set) {
+        set = new Set();
+        workerListeners.set(type, set);
+      }
+      set.add(listener);
+    },
+    removeEventListener(type: string, listener: EventListener) {
+      workerListeners.get(type)?.delete(listener);
+    },
+    terminate: vi.fn(),
+  } as unknown as Worker;
+}
+
+function dispatchWorkerError(message: string): void {
+  const event = { message } as ErrorEvent;
+  for (const listener of workerListeners.get('error') ?? []) {
+    listener.call(globalThis, event);
+  }
+}
+
+vi.mock('comlink', () => ({
+  wrap: vi.fn(() => mockRemote),
+}));
+
+vi.mock('./transports/createWorkerTransport', () => ({
+  createWorkerTransport: vi.fn(() => ({
+    configure: vi.fn(async () => undefined),
+    diagnostics: vi.fn(async () => ({ mode: 'comlink' as const })),
+    mode: () => 'comlink' as const,
+    fallbackReason: () => undefined,
+  })),
+}));
+
+describe('WorkerSerializedSource.initialize', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockRemote = {
+      initialize: vi.fn(),
+      configureTransport: vi.fn(),
+      getTransportDiagnostics: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('waits longer than the former 30s timeout without failing', async () => {
+    let resolveInitialize!: (value: Initialization) => void;
+    mockRemote.initialize.mockReturnValue(
+      new Promise<Initialization>((resolve) => {
+        resolveInitialize = resolve;
+      }),
+    );
+
+    const source = new WorkerSerializedSource(createMockWorker());
+    const pending = source.initialize({ file: new Blob(['x']) });
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    resolveInitialize(mockInitialization);
+
+    await expect(pending).resolves.toEqual(mockInitialization);
+  });
+
+  it('propagates worker initialize rejection without a timed-out message', async () => {
+    mockRemote.initialize.mockRejectedValue(new Error('HTTP 404'));
+
+    const source = new WorkerSerializedSource(createMockWorker());
+
+    await expect(source.initialize({ url: 'https://example.com/file.mcap' })).rejects.toThrow('HTTP 404');
+  });
+
+  it('rejects with WorkerSourceCancelledError when terminate is called during initialize', async () => {
+    mockRemote.initialize.mockReturnValue(new Promise<Initialization>(() => undefined));
+
+    const worker = createMockWorker();
+    const source = new WorkerSerializedSource(worker);
+    const pending = source.initialize({ file: new Blob(['x']) });
+
+    await Promise.resolve();
+    source.terminate();
+
+    await expect(pending).rejects.toBeInstanceOf(WorkerSourceCancelledError);
+    expect(worker.terminate).toHaveBeenCalled();
+  });
+
+  it('rejects when the worker emits an error event during initialize', async () => {
+    mockRemote.initialize.mockReturnValue(new Promise<Initialization>(() => undefined));
+
+    const source = new WorkerSerializedSource(createMockWorker());
+    const pending = source.initialize({ file: new Blob(['x']) });
+
+    await Promise.resolve();
+    dispatchWorkerError('Worker script failed');
+
+    await expect(pending).rejects.toThrow('Worker script failed');
+  });
+});

--- a/src/infra/workers/WorkerSerializedSource.ts
+++ b/src/infra/workers/WorkerSerializedSource.ts
@@ -17,7 +17,16 @@ import { createWorkerTransport } from "./transports/createWorkerTransport";
 import { SabTransport } from "./transports/SabTransport";
 import type { WorkerTransport } from "./transports/BaseWorkerTransport";
 
-const INITIALIZE_TIMEOUT_MS = 30_000;
+export class WorkerSourceCancelledError extends Error {
+  constructor() {
+    super("Worker initialize cancelled");
+    this.name = "WorkerSourceCancelledError";
+  }
+}
+
+export function isWorkerSourceCancelledError(error: unknown): error is WorkerSourceCancelledError {
+  return error instanceof WorkerSourceCancelledError;
+}
 
 type ResolveHighFrequencyLaneOptions = {
   preferSharedView?: boolean;
@@ -39,6 +48,7 @@ export class WorkerSerializedSource {
   private _stalePayloadRefs = 0;
   private _ringReader?: SharedPayloadRing;
   private _workerFailure?: Error;
+  private _pendingInitializeReject?: (error: Error) => void;
 
   constructor(worker: Worker) {
     this._worker = worker;
@@ -78,7 +88,7 @@ export class WorkerSerializedSource {
         this._transportConfigured = true;
       }
       const result = await this._raceWorkerFailure(
-        this._withTimeout(this._remote.initialize(sanitizedArgs), INITIALIZE_TIMEOUT_MS, "Worker initialize timed out"),
+        this._wrapAbortableInitialize(this._remote.initialize(sanitizedArgs)),
       );
       console.log("WorkerSerializedSource: initialize result received");
       return result;
@@ -120,20 +130,32 @@ export class WorkerSerializedSource {
     });
   }
 
-  private async _withTimeout<T>(operation: Promise<T>, timeoutMs: number, message: string): Promise<T> {
-    let timeoutId: ReturnType<typeof globalThis.setTimeout> | undefined;
-    try {
-      return await Promise.race([
-        operation,
-        new Promise<T>((_, reject) => {
-          timeoutId = globalThis.setTimeout(() => reject(new Error(message)), timeoutMs);
-        }),
-      ]);
-    } finally {
-      if (timeoutId !== undefined) {
-        globalThis.clearTimeout(timeoutId);
-      }
-    }
+  private _wrapAbortableInitialize<T>(operation: Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      this._pendingInitializeReject = (error) => {
+        reject(error);
+      };
+      operation.then(
+        (value) => {
+          this._clearPendingInitialize();
+          resolve(value);
+        },
+        (error: unknown) => {
+          this._clearPendingInitialize();
+          reject(errorFromUnknown(error));
+        },
+      );
+    });
+  }
+
+  private _clearPendingInitialize(): void {
+    this._pendingInitializeReject = undefined;
+  }
+
+  private _abortPendingInitialize(error: Error): void {
+    const reject = this._pendingInitializeReject;
+    this._clearPendingInitialize();
+    reject?.(error);
   }
 
   async getMessageCursor(args: MessageIteratorArgs): Promise<IMessageCursor<unknown>> {
@@ -242,7 +264,8 @@ export class WorkerSerializedSource {
     return this._fallbackReason;
   }
 
-  terminate() {
+  terminate(): void {
+    this._abortPendingInitialize(new WorkerSourceCancelledError());
     this._worker.terminate();
   }
 

--- a/src/shared/intl/messages/en/welcome.json
+++ b/src/shared/intl/messages/en/welcome.json
@@ -51,8 +51,8 @@
   "welcome.fileTypes": "mcap · bag · db3 · hdf5 · bvh",
   "welcome.directoryHint": "All matching files in folder",
   "welcome.loadingTitle": "Opening…",
-  "welcome.loadingHint": "Parsing index — large or remote files may take a moment.",
-  "welcome.changeUrl": "Different URL",
+  "welcome.loadingPhase.preparing": "Preparing…",
+  "welcome.cancelLoading": "Cancel",
   "welcome.manualOpenFileHint": "Please manually open the {name} file.",
   "welcome.manualOpenFolderHint": "Please manually open the {name} folder."
 }

--- a/src/shared/intl/messages/ja/welcome.json
+++ b/src/shared/intl/messages/ja/welcome.json
@@ -51,8 +51,8 @@
   "welcome.fileTypes": "mcap · bag · db3 · hdf5 · bvh",
   "welcome.directoryHint": "フォルダ内の該当ファイルすべて",
   "welcome.loadingTitle": "開いています…",
-  "welcome.loadingHint": "索引を解析中です。大きなファイルは時間がかかることがあります。",
-  "welcome.changeUrl": "URL を変更",
+  "welcome.loadingPhase.preparing": "準備中…",
+  "welcome.cancelLoading": "キャンセル",
   "welcome.manualOpenFileHint": "{name} ファイルを手動で開いてください。",
   "welcome.manualOpenFolderHint": "{name} フォルダを手動で開いてください。"
 }

--- a/src/shared/intl/messages/zh/welcome.json
+++ b/src/shared/intl/messages/zh/welcome.json
@@ -51,8 +51,8 @@
   "welcome.fileTypes": "mcap · bag · db3 · hdf5 · bvh",
   "welcome.directoryHint": "导入文件夹内全部匹配文件",
   "welcome.loadingTitle": "正在打开…",
-  "welcome.loadingHint": "正在解析索引，大文件或远程链接可能稍慢。",
-  "welcome.changeUrl": "更换链接",
+  "welcome.loadingPhase.preparing": "准备中…",
+  "welcome.cancelLoading": "取消",
   "welcome.manualOpenFileHint": "请手动打开 {name} 文件。",
   "welcome.manualOpenFolderHint": "请手动打开 {name} 文件夹。"
 }

--- a/src/shared/ui/skeleton.tsx
+++ b/src/shared/ui/skeleton.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+import { cn } from '@/shared/lib/utils';
+
+function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('animate-pulse rounded-md bg-muted', className)} {...props} />;
+}
+
+export { Skeleton };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -46,8 +46,24 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    // Only exclude direct WASM packages — Vite cannot pre-bundle their binary assets.
-    exclude: [
+    // Playback workers are imported only after a dataset is opened. Pre-bundle their
+    // transitive parser/decompression deps up front so first-open in dev does not
+    // trigger Vite's "new dependencies optimized" reload and bounce back to home.
+    include: [
+      '@foxglove/omgidl-parser',
+      '@foxglove/omgidl-serialization',
+      '@foxglove/ros2idl-parser',
+      '@foxglove/rosmsg',
+      '@foxglove/rosmsg-serialization',
+      '@foxglove/rosmsg2-serialization',
+      '@mcap/core',
+      'eventemitter3',
+      'flatbuffers/js/flexbuffers.js',
+      'fzstd',
+      'intervals-fn',
+      'lz4js',
+      'protobufjs',
+      'protobufjs/ext/descriptor',
       '@ioai/hdf5',
     ],
   },


### PR DESCRIPTION
## Description

Release **v1.3.3** with a clearer file-open loading experience and more reliable worker startup in dev.

- **In-player loading overlay**: While a recording is opening, show a centered overlay on the viewer (spinner, source name, preparing message) instead of blocking the welcome screen. Loading UI is shared via new `LoadingOverlay` and removed from `WelcomeScreen`.
- **Cancellable worker init**: `WorkerSerializedSource.initialize()` can be aborted; exposes `WorkerSourceCancelledError` / `isWorkerSourceCancelledError()`. `RosViewerImpl` tears down in-flight init when the user cancels or switches files, without surfacing a false error.
- **Dev first-open stability**: Pre-bundle playback-worker transitive deps in Vite `optimizeDeps.include` so opening a dataset in dev no longer triggers “new dependencies optimized” reloads that bounce the app back to home.
- **Sidebar**: Minor loading-state polish while a source is preparing.
- **Tests**: Unit coverage for initialize cancellation and worker error paths in `WorkerSerializedSource.test.ts`.
- **Version**: `1.3.2` → `1.3.3`.

## Motivation / related issue

Opening large MCAP/bag/HDF5 files felt abrupt: the welcome screen disappeared with little feedback, and cancelling or switching files during worker init could leave confusing state. In Vite dev, the first open after adding parser dependencies could trigger a full-page reload.

Follow-up to the v1.3.2 release (HDF5 1.0.0 / E2E fixtures); no linked issue.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation update
- [ ] Refactor / internal cleanup (no behavior change)

## Checklist

- [x] `npm run lint` passes with no errors
- [x] `npm test` passes (unit tests)
- [ ] `npm run build` and `npm run build:lib` succeed
- [x] New behavior is covered by tests (or explain why tests aren't applicable)
- [ ] Documentation updated (README, API.md, EMBEDDING.md) if the public API changed
- [ ] **Breaking change**: all affected call sites updated and migration path described in PR description

## API compatibility

No changes to `src/entrypoints/index.ts` exports.

Internal worker layer only (additive, non-breaking for embedders):

- `WorkerSourceCancelledError` and `isWorkerSourceCancelledError()` — used when user cancels load; embedders that call worker sources directly may catch this instead of treating it as a failure.
- No changes to `Player`, `PlaybackControlsApi`, or public React component props.

## Screenshots / recordings

<!-- Optional: screen recording of open file → overlay with Cancel → switch/cancel without error toast -->