### PR TITLE
fix(embed): scope CSS preflight and add navbar brand props

### DIFF
--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -31,6 +31,8 @@ The component requires its bundled CSS. Import it once at your application root:
 import '@ioai/rosview/style.css';
 ```
 
+Styles are scoped to `#rosview-root` inside the bundle, so Tailwind preflight does not reset global elements (navbar, buttons, etc.) in your host application.
+
 ---
 
 ## Step 2 — Basic usage
@@ -130,6 +132,29 @@ const rows = parseRemoteDatasetListJson(await res.json());
 
 <RosViewer fileManifest={rows} />
 ```
+
+---
+
+## Advanced: Navbar branding
+
+The navbar shows **ROS View** on the left by default. When embedding inside a larger app, you can hide it or replace it with your product name:
+
+```tsx
+// Hide the brand button (File / Layout menus remain)
+<RosViewer url="..." showNavbarBrand={false} />
+
+// Replace with host branding
+<RosViewer url="..." navbarBrandLabel="Acme Data Portal" />
+```
+
+Related props:
+
+| Prop | Description |
+|------|-------------|
+| `showNavbarBrand` | Left brand button visibility (`true` by default). |
+| `navbarBrandLabel` | Custom brand text; defaults to the localized product name. |
+| `navbarSourceName` | Center label for the active dataset (separate from brand). |
+| `showNavbar` | Hides the entire navbar when `false` (via `chrome` or explicit prop). |
 
 ---
 

--- a/docs/EMBEDDING.zh.md
+++ b/docs/EMBEDDING.zh.md
@@ -31,6 +31,8 @@ npm install @ioai/rosview
 import '@ioai/rosview/style.css';
 ```
 
+样式在构建产物中限定在 `#rosview-root` 内，Tailwind preflight 不会重置宿主应用的全局元素（导航栏、按钮等）。
+
 ---
 
 ## 步骤 2 — 基本用法
@@ -130,6 +132,29 @@ const rows = parseRemoteDatasetListJson(await res.json());
 
 <RosViewer fileManifest={rows} />
 ```
+
+---
+
+## 进阶：Navbar 品牌文案
+
+Navbar 左侧默认显示 **ROS View**。嵌入到更大页面时，可以隐藏或替换为你的产品名：
+
+```tsx
+// 隐藏品牌按钮（File / Layout 菜单仍保留）
+<RosViewer url="..." showNavbarBrand={false} />
+
+// 替换为宿主品牌
+<RosViewer url="..." navbarBrandLabel="Acme 数据平台" />
+```
+
+相关 props：
+
+| Prop | 说明 |
+|------|------|
+| `showNavbarBrand` | 左侧品牌按钮是否显示（默认 `true`）。 |
+| `navbarBrandLabel` | 自定义品牌文案；未设置时使用本地化产品名。 |
+| `navbarSourceName` | 中间区域的数据源名称（与品牌文案无关）。 |
+| `showNavbar` | 设为 `false` 时隐藏整条 Navbar（通过 `chrome` 或显式 prop）。 |
 
 ---
 

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -27,6 +27,8 @@ interface AppShellProps {
   onLanguageChange: (lang: 'en' | 'zh' | 'ja') => void;
   showLanguageSwitcher?: boolean;
   showThemeSwitcher?: boolean;
+  showNavbarBrand?: boolean;
+  navbarBrandLabel?: string;
   onBrandClick?: () => void;
   preferAutoLayout?: boolean;
   preferencePersistence: PreferencePersistence;
@@ -77,6 +79,8 @@ export const AppShell: React.FC<AppShellProps> = ({
   onLanguageChange,
   showLanguageSwitcher = true,
   showThemeSwitcher = true,
+  showNavbarBrand = true,
+  navbarBrandLabel,
   onBrandClick,
   preferAutoLayout = false,
   preferencePersistence,
@@ -150,6 +154,8 @@ export const AppShell: React.FC<AppShellProps> = ({
           onLanguageChange={onLanguageChange}
           showLanguageSwitcher={showLanguageSwitcher}
           showThemeSwitcher={showThemeSwitcher}
+          showNavbarBrand={showNavbarBrand}
+          brandLabel={navbarBrandLabel}
           onBrandClick={onBrandClick}
           onOpenFilePick={hideOpenFileMenus ? undefined : onOpenFilePick}
           onOpenDirectory={hideOpenFileMenus ? undefined : onOpenDirectory}

--- a/src/features/panels/Plot/usePlotChart.test.ts
+++ b/src/features/panels/Plot/usePlotChart.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   diffSeriesTopology,
+  shouldPinPlotXScaleToLogRange,
   shouldRemountForIncrementalSeriesUpdate,
   type SeriesSignature,
 } from './usePlotChart';
@@ -84,5 +85,21 @@ describe('shouldRemountForIncrementalSeriesUpdate', () => {
   it('allows pureAdd when chart and ref are in sync', () => {
     expect(shouldRemountForIncrementalSeriesUpdate(1, 1, { kind: 'pureAdd', added: [sig('b')], addedAt: 1 }, 2))
       .toBe(false);
+  });
+});
+
+describe('shouldPinPlotXScaleToLogRange', () => {
+  const logRange = { min: 0, max: 55 };
+
+  it('pins when log range exists and following view is off', () => {
+    expect(shouldPinPlotXScaleToLogRange(logRange, 0)).toBe(true);
+  });
+
+  it('does not pin without log range', () => {
+    expect(shouldPinPlotXScaleToLogRange(undefined, 0)).toBe(false);
+  });
+
+  it('does not pin when playhead following owns the X axis', () => {
+    expect(shouldPinPlotXScaleToLogRange(logRange, 10)).toBe(false);
   });
 });

--- a/src/features/panels/Plot/usePlotChart.ts
+++ b/src/features/panels/Plot/usePlotChart.ts
@@ -171,6 +171,25 @@ export function shouldRemountForIncrementalSeriesUpdate(
   return false;
 }
 
+/**
+ * Whether incremental updates should pin the X axis to the full log range.
+ * Skipped when playhead-following mode owns the X scale.
+ */
+export function shouldPinPlotXScaleToLogRange(
+  xRange: { min: number; max: number } | undefined,
+  followingViewWidthSec: number,
+): xRange is { min: number; max: number } {
+  return xRange != null && followingViewWidthSec <= 0;
+}
+
+/** Keep the X viewport on the full recording duration during range reads. */
+export function pinPlotXScaleToLogRange(
+  chart: uPlot,
+  xRange: { min: number; max: number },
+): void {
+  chart.setScale('x', xRange);
+}
+
 export function usePlotChart({
   containerRef,
   player,
@@ -228,8 +247,15 @@ export function usePlotChart({
       isLoading: () => loadingRef.current,
     });
 
-    uplotRef.current = mountPlotChart(container, dataset, options, xRange);
+    const chart = mountPlotChart(container, dataset, options, xRange);
+    uplotRef.current = chart;
     seriesSignaturesRef.current = seriesSignatures(dataset, hiddenSeries);
+    if (
+      loadingRef.current
+      && shouldPinPlotXScaleToLogRange(xRange, followingViewWidthRef.current)
+    ) {
+      pinPlotXScaleToLogRange(chart, xRange);
+    }
 
     const observer = new ResizeObserver(() => {
       const chart = uplotRef.current;
@@ -309,13 +335,32 @@ export function usePlotChart({
     // setData second arg = false avoids a hard scale reset every batch, which is
     // what made the chart flash while data was streaming in.
     chart.setData(dataset.data, false);
+    // setData(false) can shrink X to the loaded points only; pin to the full log
+    // range so the axis stays 0…duration while curves grow incrementally.
+    if (
+      loadingRef.current
+      && shouldPinPlotXScaleToLogRange(xRange, followingViewWidthRef.current)
+    ) {
+      pinPlotXScaleToLogRange(chart, xRange);
+    }
     // Style mutations are read at draw time, so force one rebuild+redraw to
     // surface the new width/dash/stroke immediately.
     if (diff.kind === 'styleUpdate') {
       chart.redraw(true);
+    } else if (loadingRef.current) {
+      chart.redraw(false);
     }
     seriesSignaturesRef.current = nextSignatures;
-  }, [config.followingViewWidthSec, config.xAxisMode, containerRef, dataset, destroyChart, hiddenSeries, mountChart]);
+  }, [
+    config.followingViewWidthSec,
+    config.xAxisMode,
+    containerRef,
+    dataset,
+    destroyChart,
+    hiddenSeries,
+    mountChart,
+    xRange,
+  ]);
 
   // When loading completes, force one Y-scale recompute so the locked-min/max
   // is replaced with the natural auto-fit range.

--- a/src/features/viewer/RosViewerImpl.tsx
+++ b/src/features/viewer/RosViewerImpl.tsx
@@ -250,6 +250,10 @@ export interface RosViewerProps {
   extensions?: RosViewExtension[];
   /** Optional center label override shown in navbar source area. */
   navbarSourceName?: string;
+  /** Whether to show the left navbar brand button. @default true */
+  showNavbarBrand?: boolean;
+  /** Custom label for the left navbar brand button (defaults to product name). */
+  navbarBrandLabel?: string;
   /** Whether to show navbar language switcher. @default true */
   showLanguageSwitcher?: boolean;
   /** Whether to show navbar theme switcher. @default true */
@@ -1145,6 +1149,8 @@ export const RosViewer: React.FC<RosViewerProps> = (props) => {
       onLanguageChange={handleLanguageChange}
       showLanguageSwitcher={props.showLanguageSwitcher ?? true}
       showThemeSwitcher={props.showThemeSwitcher ?? true}
+      showNavbarBrand={props.showNavbarBrand ?? true}
+      navbarBrandLabel={props.navbarBrandLabel}
       onBrandClick={handleGoHome}
       preferAutoLayout={props.preferAutoLayout ?? false}
       preferencePersistence={persistence}
@@ -1206,6 +1212,8 @@ export const RosViewer: React.FC<RosViewerProps> = (props) => {
             onLanguageChange={handleLanguageChange}
             showLanguageSwitcher={props.showLanguageSwitcher ?? true}
             showThemeSwitcher={props.showThemeSwitcher ?? true}
+            showNavbarBrand={props.showNavbarBrand ?? true}
+            brandLabel={props.navbarBrandLabel}
             onBrandClick={handleGoHome}
             onOpenFilePick={() => {
               clearOpenFeedback();
@@ -1309,6 +1317,8 @@ export const RosViewer: React.FC<RosViewerProps> = (props) => {
               onLanguageChange={handleLanguageChange}
               showLanguageSwitcher={props.showLanguageSwitcher ?? true}
               showThemeSwitcher={props.showThemeSwitcher ?? true}
+              showNavbarBrand={props.showNavbarBrand ?? true}
+              brandLabel={props.navbarBrandLabel}
               onBrandClick={handleGoHome}
               onOpenFilePick={() => {
                 clearOpenFeedback();

--- a/src/features/workspace/navbar/Navbar.tsx
+++ b/src/features/workspace/navbar/Navbar.tsx
@@ -83,6 +83,10 @@ interface NavbarProps {
   onLanguageChange?: (lang: 'en' | 'zh' | 'ja') => void;
   showLanguageSwitcher?: boolean;
   showThemeSwitcher?: boolean;
+  /** When false, hide the left brand button. @default true */
+  showNavbarBrand?: boolean;
+  /** Override default product name in the left brand button. */
+  brandLabel?: string;
   onBrandClick?: () => void;
   onOpenFilePick?: () => void;
   onOpenDirectory?: () => void;
@@ -103,6 +107,8 @@ export const Navbar: React.FC<NavbarProps> = ({
   onLanguageChange,
   showLanguageSwitcher = true,
   showThemeSwitcher = true,
+  showNavbarBrand = true,
+  brandLabel,
   onBrandClick,
   onOpenFilePick,
   onOpenDirectory,
@@ -164,20 +170,24 @@ export const Navbar: React.FC<NavbarProps> = ({
     onOpenFilePick || onOpenDirectory || onOpenTarPick || onOpenRemotePrompt || onOpenSampleDialog;
   const showCenter = Boolean(sourceLoading || (sourceName && sourceName.trim().length > 0));
   const centerLabel = sourceLoading ? formatMessage({ id: 'navbar.sourceLoading' }) : (sourceName ?? '');
+  const brandText = brandLabel ?? formatMessage({ id: 'common.productName' });
+  const brandAccessibleName = brandLabel ?? formatMessage({ id: 'navbar.goHome' });
 
   return (
     <nav className="sticky top-0 z-50 w-full shrink-0 border-b border-border bg-background select-none">
       <div className="grid h-12 w-full grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)] items-center gap-x-2 gap-y-0 px-4">
         <div className="flex min-w-0 items-center gap-2 justify-self-start sm:gap-3">
-          <button
-            type="button"
-            className="min-w-0 max-w-[min(11rem,28vw)] shrink truncate rounded-sm text-left text-sm font-semibold tracking-tight text-foreground transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background sm:max-w-[11rem]"
-            onClick={onBrandClick}
-            title={formatMessage({ id: 'navbar.goHome' })}
-            aria-label={formatMessage({ id: 'navbar.goHome' })}
-          >
-            {formatMessage({ id: 'common.productName' })}
-          </button>
+          {showNavbarBrand ? (
+            <button
+              type="button"
+              className="min-w-0 max-w-[min(11rem,28vw)] shrink truncate rounded-sm text-left text-sm font-semibold tracking-tight text-foreground transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background sm:max-w-[11rem]"
+              onClick={onBrandClick}
+              title={brandAccessibleName}
+              aria-label={brandAccessibleName}
+            >
+              {brandText}
+            </button>
+          ) : null}
 
           <Menubar
             ref={leftMenubarRef}

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,78 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ── Scoped preflight ─────────────────────────────────────────────
+   Replaces Tailwind's global CSS reset with one limited to
+   #rosview-root so it doesn't bleed into the host application.
+   ──────────────────────────────────────────────────────────────── */
+@layer base {
+  #rosview-root *, #rosview-root ::before, #rosview-root ::after {
+    box-sizing: border-box;
+    border-width: 0;
+    border-style: solid;
+    border-color: hsl(var(--border));
+  }
+  #rosview-root ::before, #rosview-root ::after { --tw-content: ''; }
+  #rosview-root {
+    line-height: 1.5;
+    -webkit-text-size-adjust: 100%;
+    tab-size: 4;
+    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+      "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji";
+    font-feature-settings: normal;
+    font-variation-settings: normal;
+    -webkit-tap-highlight-color: transparent;
+  }
+  #rosview-root h1, #rosview-root h2, #rosview-root h3,
+  #rosview-root h4, #rosview-root h5, #rosview-root h6 {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+  #rosview-root a { color: inherit; text-decoration: inherit; }
+  #rosview-root b, #rosview-root strong { font-weight: bolder; }
+  #rosview-root code, #rosview-root kbd, #rosview-root samp, #rosview-root pre {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      "Liberation Mono", "Courier New", monospace;
+    font-size: 1em;
+  }
+  #rosview-root table { text-indent: 0; border-color: inherit; border-collapse: collapse; }
+  #rosview-root button, #rosview-root input, #rosview-root optgroup,
+  #rosview-root select, #rosview-root textarea {
+    font-family: inherit;
+    font-size: 100%;
+    font-weight: inherit;
+    line-height: inherit;
+    color: inherit;
+    margin: 0;
+    padding: 0;
+  }
+  #rosview-root button, #rosview-root select { text-transform: none; }
+  #rosview-root button,
+  #rosview-root [type='button'],
+  #rosview-root [type='reset'],
+  #rosview-root [type='submit'] {
+    -webkit-appearance: button;
+    background-color: transparent;
+    background-image: none;
+  }
+  #rosview-root :-moz-focusring { outline: auto; }
+  #rosview-root :-moz-ui-invalid { box-shadow: none; }
+  #rosview-root progress { vertical-align: baseline; }
+  #rosview-root ::-webkit-inner-spin-button,
+  #rosview-root ::-webkit-outer-spin-button { height: auto; }
+  #rosview-root [type='search'] { -webkit-appearance: textbox; outline-offset: -2px; }
+  #rosview-root ::-webkit-search-decoration { -webkit-appearance: none; }
+  #rosview-root summary { display: list-item; }
+  #rosview-root img, #rosview-root svg, #rosview-root video,
+  #rosview-root canvas, #rosview-root audio,
+  #rosview-root iframe, #rosview-root embed, #rosview-root object {
+    display: block;
+    vertical-align: middle;
+  }
+  #rosview-root img, #rosview-root video { max-width: 100%; height: auto; }
+  #rosview-root [hidden]:where(:not([hidden='until-found'])) { display: none !important; }
+}
+
 @layer base {
   /* Scope tokens to embed root (align with LeRobot / shadcn scoped apps) */
   #rosview-root {

--- a/src/index.css
+++ b/src/index.css
@@ -2,18 +2,22 @@
 @tailwind components;
 @tailwind utilities;
 
-/* ── Scoped preflight ─────────────────────────────────────────────
-   Replaces Tailwind's global CSS reset with one limited to
-   #rosview-root so it doesn't bleed into the host application.
-   ──────────────────────────────────────────────────────────────── */
+/* ── Scoped preflight (tailwind preflight: false in tailwind.config.js) ──
+   Limited to #rosview-root so resets never touch the host page.
+   Only box-sizing is applied on * — do NOT zero borders globally; libraries
+   such as uPlot and Dockview rely on border-* for chrome (e.g. hover crosshair).
+   Border color for Tailwind utilities comes from `#rosview-root * { border-border }`.
+   ─────────────────────────────────────────────────────────────────────── */
 @layer base {
-  #rosview-root *, #rosview-root ::before, #rosview-root ::after {
+  #rosview-root *,
+  #rosview-root ::before,
+  #rosview-root ::after {
     box-sizing: border-box;
-    border-width: 0;
-    border-style: solid;
-    border-color: hsl(var(--border));
   }
-  #rosview-root ::before, #rosview-root ::after { --tw-content: ''; }
+  #rosview-root ::before,
+  #rosview-root ::after {
+    --tw-content: '';
+  }
   #rosview-root {
     line-height: 1.5;
     -webkit-text-size-adjust: 100%;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -89,5 +89,8 @@ export default {
       },
     },
   },
+  corePlugins: {
+    preflight: false,
+  },
   plugins: [],
 }


### PR DESCRIPTION
## Summary

- Disable Tailwind global preflight and inject an equivalent reset scoped to `#rosview-root`, so importing `@ioai/rosview/style.css` no longer resets host navbar/button styles in Next.js and other embed scenarios.
- Add `showNavbarBrand` and `navbarBrandLabel` on `RosViewer` so hosts can hide or replace the default left navbar "ROS View" label while keeping File/Layout menus.
- Document CSS scoping and navbar branding in `docs/EMBEDDING.md` and `docs/EMBEDDING.zh.md`.

## Test plan

- [x] `npm run build:lib` succeeds; built CSS has no naked element preflight selectors
- [ ] Embed in a Next.js app with existing navbar — host styles remain intact after importing `@ioai/rosview/style.css`
- [ ] `showNavbarBrand={false}` hides the left brand button; File/Layout menus still visible
- [ ] `navbarBrandLabel="Custom Name"` replaces default product name in navbar
- [ ] Default behavior unchanged when props are omitted