### PR TITLE
fix(css): stabilize scoped rosview styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ioai/rosview",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ioai/rosview",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ioai/rosview",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "High-performance robotics data visualization for MCAP, ROS bag, ROS2 db3, HDF5 and BVH — embeddable React component and standalone SPA",
   "keywords": [
     "ros",

--- a/src/entrypoints/App.tsx
+++ b/src/entrypoints/App.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useReducer } from 'react';
 import { RosViewer } from '@/features/viewer/RosViewer';
-import '../index.css';
 
 function useLocationSearchSync() {
   const [, bump] = useReducer((n: number) => n + 1, 0);
@@ -24,7 +23,7 @@ function App() {
   const syncLocationSearch = useLocationSearchSync();
   const url = readSpaUrlFromQuery();
   return (
-    <div className="w-screen h-screen">
+    <div style={{ width: '100vw', height: '100vh' }}>
       <RosViewer
         url={url}
         urlState="spa"

--- a/src/entrypoints/main.tsx
+++ b/src/entrypoints/main.tsx
@@ -1,4 +1,5 @@
 import { createRoot } from 'react-dom/client';
+import './standalone.css';
 import '../index.css';
 import App from './App.tsx';
 

--- a/src/entrypoints/standalone.css
+++ b/src/entrypoints/standalone.css
@@ -1,0 +1,16 @@
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  min-width: 320px;
+}
+
+body,
+p {
+  margin: 0;
+}

--- a/src/features/viewer/RosViewProvider.tsx
+++ b/src/features/viewer/RosViewProvider.tsx
@@ -86,12 +86,14 @@ export const RosViewProvider: React.FC<RosViewProviderProps> = ({
         data-language={language}
         data-theme={resolvedTheme}
         data-player-presence={playerPresence}
-        className={`w-full h-full ${resolvedTheme === 'dark' ? 'dark' : ''}`}
+        className={`rosview-root-shell ${resolvedTheme === 'dark' ? 'dark' : ''}`}
       >
-        <IntlProvider locale={intlLocaleFor(language)} defaultLocale="en" messages={messages}>
-          {children}
-          <Toaster theme={resolvedTheme} />
-        </IntlProvider>
+        <div className="h-full w-full min-h-0 min-w-0">
+          <IntlProvider locale={intlLocaleFor(language)} defaultLocale="en" messages={messages}>
+            {children}
+            <Toaster theme={resolvedTheme} />
+          </IntlProvider>
+        </div>
       </div>
     </RosViewThemeContext.Provider>
   );

--- a/src/features/workspace/playback/PlaybackBar.tsx
+++ b/src/features/workspace/playback/PlaybackBar.tsx
@@ -486,19 +486,19 @@ export const PlaybackBar: React.FC<PlaybackBarProps> = ({ player, extensionConte
           <div
             ref={hoverLineRef}
             data-testid="playback-hover-line"
-            className="pointer-events-none absolute top-1/2 z-[2] h-6 w-px -translate-x-1/2 -translate-y-1/2 bg-primary/55 opacity-0"
+            className="ros-playback-center-xy pointer-events-none absolute top-1/2 z-[2] h-6 w-px bg-primary/55 opacity-0"
             style={{ left: '0%' }}
           />
           <div
             ref={thumbRef}
             data-testid="playback-thumb"
-            className="pointer-events-none absolute top-1/2 z-[3] h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full border border-primary bg-background"
+            className="ros-playback-center-xy pointer-events-none absolute top-1/2 z-[3] h-3 w-3 rounded-full border border-primary bg-background"
             style={{ left: '0%' }}
           />
           <div
             ref={hoverTooltipRef}
             data-testid="playback-hover-time"
-            className="pointer-events-none absolute -top-8 z-10 -translate-x-1/2 rounded-md border border-border bg-popover px-2 py-1 text-[10px] font-mono text-popover-foreground opacity-0 shadow-lg"
+            className="ros-playback-center-x pointer-events-none absolute -top-8 z-10 rounded-md border border-border bg-popover px-2 py-1 text-[10px] font-mono text-popover-foreground opacity-0 shadow-lg"
             style={{ left: '0%' }}
           />
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -4,9 +4,9 @@
 
 /* ── Scoped preflight (tailwind preflight: false in tailwind.config.js) ──
    Limited to #rosview-root so resets never touch the host page.
-   Only box-sizing is applied on * — do NOT zero borders globally; libraries
-   such as uPlot and Dockview rely on border-* for chrome (e.g. hover crosshair).
-   Border color for Tailwind utilities comes from `#rosview-root * { border-border }`.
+   Do not zero borders on every element: libraries such as uPlot and Dockview
+   rely on their own border chrome. Instead, initialize only Tailwind border
+   width utilities so classes like `border` / `border-b` are visible again.
    ─────────────────────────────────────────────────────────────────────── */
 @layer base {
   #rosview-root *,
@@ -19,6 +19,10 @@
     --tw-content: '';
   }
   #rosview-root {
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+    min-height: 0;
     line-height: 1.5;
     -webkit-text-size-adjust: 100%;
     tab-size: 4;
@@ -32,6 +36,21 @@
   #rosview-root h4, #rosview-root h5, #rosview-root h6 {
     font-size: inherit;
     font-weight: inherit;
+  }
+  #rosview-root :where(blockquote, dl, dd, h1, h2, h3, h4, h5, h6, hr, figure, p, pre) {
+    margin: 0;
+  }
+  #rosview-root :where(ol, ul, menu) {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  #rosview-root :where(fieldset) {
+    margin: 0;
+    padding: 0;
+  }
+  #rosview-root :where(legend) {
+    padding: 0;
   }
   #rosview-root a { color: inherit; text-decoration: inherit; }
   #rosview-root b, #rosview-root strong { font-weight: bolder; }
@@ -50,12 +69,16 @@
     color: inherit;
     margin: 0;
     padding: 0;
+    border-width: 0;
+    border-style: solid;
+    border-color: hsl(var(--border));
   }
   #rosview-root button, #rosview-root select { text-transform: none; }
   #rosview-root button,
   #rosview-root [type='button'],
   #rosview-root [type='reset'],
   #rosview-root [type='submit'] {
+    appearance: button;
     -webkit-appearance: button;
     background-color: transparent;
     background-image: none;
@@ -65,7 +88,7 @@
   #rosview-root progress { vertical-align: baseline; }
   #rosview-root ::-webkit-inner-spin-button,
   #rosview-root ::-webkit-outer-spin-button { height: auto; }
-  #rosview-root [type='search'] { -webkit-appearance: textbox; outline-offset: -2px; }
+  #rosview-root [type='search'] { appearance: textfield; -webkit-appearance: textbox; outline-offset: -2px; }
   #rosview-root ::-webkit-search-decoration { -webkit-appearance: none; }
   #rosview-root summary { display: list-item; }
   #rosview-root img, #rosview-root svg, #rosview-root video,
@@ -76,6 +99,11 @@
   }
   #rosview-root img, #rosview-root video { max-width: 100%; height: auto; }
   #rosview-root [hidden]:where(:not([hidden='until-found'])) { display: none !important; }
+  #rosview-root :where(.border, .border-x, .border-y, .border-t, .border-r, .border-b, .border-l) {
+    border-width: 0;
+    border-style: solid;
+    border-color: hsl(var(--border));
+  }
 }
 
 @layer base {
@@ -185,6 +213,16 @@
 }
 
 @layer components {
+  #rosview-root .ros-playback-center-x {
+    transform: translateX(-50%);
+    translate: none;
+  }
+
+  #rosview-root .ros-playback-center-xy {
+    transform: translate(-50%, -50%);
+    translate: none;
+  }
+
   #rosview-root .loading-spinner {
     width: 32px;
     height: 32px;


### PR DESCRIPTION
Restore scoped preflight behavior for standalone and embedded builds, and isolate playback scrubber centering from host Tailwind transforms for v1.5.3.

## Description

- Add `standalone.css` for the SPA shell (`html` / `body` / `#root` margin and full-viewport sizing) without leaking global resets into the npm library bundle.
- Extend scoped preflight under `#rosview-root`: typography/list/fieldset margin resets, form control border normalization, and Tailwind `.border*` utility initialization so shadcn-style borders render correctly with `preflight: false`.
- Fix `#rosview-root` layout: explicit root dimensions plus an inner `h-full w-full` wrapper so Tailwind utilities scoped with `important: '#rosview-root'` apply to descendants, not only to the root element itself.
- Fix standalone `App.tsx` outer shell to use inline viewport sizing instead of scoped `w-screen` / `h-screen` classes outside `#rosview-root`.
- Fix embedded playback scrubber: replace `-translate-x/y-1/2` utilities with `ros-playback-center-x` / `ros-playback-center-xy` and `translate: none` so host apps using Tailwind v4 do not double-apply `translate` (thumb offset + broken track hit-testing).
- Bump package version to `1.5.3`.

## Motivation / related issue

After `v1.5.2` scoped CSS (`important: '#rosview-root'`, `preflight: false`):

1. **Standalone site** — Missing base resets (`body`, `p` margins, visible `.border` on buttons) made the main site look broken compared to pre-1.5.x.
2. **Embedded hosts (e.g. limx-agent)** — Playback thumb appeared too high and scrubbing failed because the host’s global Tailwind v4 `translate` utilities stacked on top of rosview’s transform-based centering, and `pointer-events-none` overlays no longer hit `#playback-track`.

This PR restores predictable styling in both modes without re-enabling global preflight that would affect the host page.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation update
- [ ] Refactor / internal cleanup (no behavior change)

## Checklist

- [x] `npm run lint` passes with no errors
- [x] `npm test` passes (unit tests)
- [x] `npm run build` and `npm run build:lib` succeed
- [ ] New behavior is covered by tests (or explain why tests aren't applicable)
- [ ] Documentation updated (README, API.md, EMBEDDING.md) if the public API changed
- [ ] **Breaking change**: all affected call sites updated and migration path described in PR description

**Tests:** Visual/CSS integration fix; no new unit tests. Manually verified standalone `localhost:5173` and embedded `/visualize` playback track centering and scrubber hit-testing.

## API compatibility

N/A — no changes to `src/entrypoints/index.ts` exports. CSS-only and internal component structure changes; consumers should upgrade to `@ioai/rosview@1.5.3` and continue importing `@ioai/rosview/style.css` once published.

## Screenshots / recordings

<!-- Optional: before/after of navbar borders (standalone) and playback thumb alignment on embedded host -->