### PR TITLE
chore: bump version to 1.5.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ioai/rosview",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ioai/rosview",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ioai/rosview",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "High-performance robotics data visualization for MCAP, ROS bag, ROS2 db3, HDF5 and BVH — embeddable React component and standalone SPA",
   "keywords": [
     "ros",


### PR DESCRIPTION
Bump `@ioai/rosview` to **1.5.4** for npm publish and the `v1.5.4` release tag.

## Description

- Update `package.json` and `package-lock.json` version from `1.5.3` to `1.5.4`
- Follows the merged Plot panel improvements in #15

## Motivation / related issue

`main` still reports `1.5.3` while `v1.5.3` is already published. This version bump prepares the next release after #15.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation update
- [x] Refactor / internal cleanup (no behavior change)

## Checklist

- [x] `npm run lint` passes with no errors
- [x] `npm test` passes (unit tests)
- [ ] `npm run build` and `npm run build:lib` succeed
- [ ] New behavior is covered by tests (or explain why tests aren't applicable)
- [ ] Documentation updated (README, API.md, EMBEDDING.md) if the public API changed
- [ ] **Breaking change**: all affected call sites updated and migration path described in PR description

## API compatibility

N/A — version-only change; no exported API changes.

## Release steps after merge

1. Merge this PR
2. Push tag `v1.5.4` on `main` to trigger the release workflow (npm publish + GitHub Release)