### PR TITLE
fix(protobuf): deserialize bytes fields as Uint8Array instead of Array

### DIFF
--- a/src/infra/sources/parseChannel.ts
+++ b/src/infra/sources/parseChannel.ts
@@ -161,7 +161,7 @@ export function parseChannel(
         messageType.toObject(messageType.decode(new Uint8Array(data.buffer, data.byteOffset, data.byteLength)), {
           longs: String,
           enums: String,
-          bytes: Array,
+          bytes: Uint8Array,
           defaults: true,
         }),
     };


### PR DESCRIPTION
## Description

In `parseChannel.ts`, `protobufjs` was configured with the option `bytes: Array` during deserialization. This converted all binary fields (e.g., `data` in `foxglove.CompressedImage`) into JavaScript arrays of numbers. This broke the `instanceof Uint8Array` validation checks in the Image Panel's message handlers, preventing image topics in protobuf-encoded MCAP files (like NuScenes) from rendering. Change the configuration option to `bytes: Uint8Array` to preserve raw binary buffers and allow correct rendering of protobuf-based images.

## Motivation / related issue

As shown in the screenshots, if the image topic in the MCAP file uses Protobuf encoding, it will not be rendered in the ImagePanel. Other topics using ROS1 or CDR (ROS 2) encoding are not affected.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] `npm run lint` passes with no errors
- [x] `npm test` passes (unit tests)
- [x] `npm run build` and `npm run build:lib` succeed
- [x] New behavior is covered by tests (or explain why tests aren't applicable)
- [x] Documentation updated (README, API.md, EMBEDDING.md) if the public API changed
- [x] **Breaking change**: all affected call sites updated and migration path described in PR description

## API compatibility

N/A

## Screenshots / recordings

Before:
<img width="2878" height="1380" alt="before" src="https://github.com/user-attachments/assets/b853791d-3325-403b-87dc-2c9ade596ccc" />

After:
<img width="2876" height="1378" alt="after" src="https://github.com/user-attachments/assets/3c14751f-0ba5-4912-a371-b8bd510bc09f" />

