### PR TITLE
fix: satisfy eslint for PointCloud refs and type assertions

### DIFF
--- a/src/features/panels/ThreeD/ThreeDPanel.tsx
+++ b/src/features/panels/ThreeD/ThreeDPanel.tsx
@@ -492,9 +492,11 @@ const LivePointCloudLayer = ({
   const pendingJobRef = useRef<PointCloudParseRequest | null>(null);
   const didAutofitRef = useRef(false);
 
-  cameraRef.current = camera;
-  controlsRef.current = controls;
-  invalidateRef.current = invalidate;
+  useEffect(() => {
+    cameraRef.current = camera;
+    controlsRef.current = controls;
+    invalidateRef.current = invalidate;
+  }, [camera, controls, invalidate]);
 
   useEffect(() => {
     didAutofitRef.current = false;

--- a/src/shared/utils/pointCloud.test.ts
+++ b/src/shared/utils/pointCloud.test.ts
@@ -12,7 +12,7 @@ function packPclRgb(r: number, g: number, b: number): number {
   const packed = ((r & 0xff) << 16) | ((g & 0xff) << 8) | (b & 0xff);
   const buf = new ArrayBuffer(4);
   new Uint32Array(buf)[0] = packed;
-  return new Float32Array(buf)[0]!;
+  return new Float32Array(buf)[0];
 }
 
 function buildCloud(options: {
@@ -27,7 +27,7 @@ function buildCloud(options: {
   const data = new Uint8Array(width * options.pointStep);
   const view = new DataView(data.buffer);
   for (let i = 0; i < options.points.length; i++) {
-    options.points[i]!(view, i * options.pointStep);
+    options.points[i](view, i * options.pointStep);
   }
   return {
     header: options.frameId ? { frame_id: options.frameId } : undefined,
@@ -99,7 +99,7 @@ describe('parsePointCloud2', () => {
     expect(Array.from(parsed!.positions.subarray(0, 3))).toEqual([3, -1, -2]);
     expect(parsed!.positions[3]).toBeCloseTo(10);
     expect(parsed!.colors).toBeDefined();
-    expect(parsed!.colors![0]).not.toBeCloseTo(parsed!.colors![3]!, 2);
+    expect(parsed!.colors![0]).not.toBeCloseTo(parsed!.colors![3], 2);
   });
 
   it('does not optical-transform map-frame clouds', () => {
@@ -243,6 +243,6 @@ describe('sampleTurbo', () => {
     const b = new Float32Array(3);
     sampleTurbo(0, a, 0);
     sampleTurbo(1, b, 0);
-    expect(a[0]).not.toBeCloseTo(b[0]!, 2);
+    expect(a[0]).not.toBeCloseTo(b[0], 2);
   });
 });

--- a/src/shared/utils/pointCloud.ts
+++ b/src/shared/utils/pointCloud.ts
@@ -301,7 +301,7 @@ export function parsePointCloud2(
         colors.fill(0.5);
       } else {
         for (let i = 0; i < written; i++) {
-          const t = (tmpScalar[i]! - scalarMin) / range;
+          const t = (tmpScalar[i] - scalarMin) / range;
           const o = i * 3;
           colors[o] = t;
           colors[o + 1] = t;
@@ -314,7 +314,7 @@ export function parsePointCloud2(
       }
     } else {
       for (let i = 0; i < written; i++) {
-        sampleTurbo((tmpScalar[i]! - scalarMin) / range, colors, i * 3);
+        sampleTurbo((tmpScalar[i] - scalarMin) / range, colors, i * 3);
       }
     }
   }


### PR DESCRIPTION
## Summary

- Move `camera`/`controls`/`invalidate` ref sync out of render into `useEffect` to satisfy `react-hooks/refs`.
- Remove unnecessary non-null assertions in `pointCloud.ts` / `pointCloud.test.ts` flagged by `@typescript-eslint/no-unnecessary-type-assertion`.
- Unblocks the failed `v1.7.2` Release validate job.

## Test plan

- [x] `npm run lint`
- [x] `npx vitest run src/shared/utils/pointCloud.test.ts`