### PR TITLE
fix(image): bootstrap H.264 GOP for immediate first frame at playback start

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ioai/rosview",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ioai/rosview",
-      "version": "1.7.6",
+      "version": "1.7.7",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ioai/rosview",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "description": "High-performance robotics data visualization for MCAP, ROS bag, ROS2 db3, HDF5 and BVH — embeddable React component and standalone SPA",
   "keywords": [
     "ros",

--- a/src/features/panels/Image/ImagePanel.tsx
+++ b/src/features/panels/Image/ImagePanel.tsx
@@ -14,9 +14,10 @@ import type {
 } from './core/imageWorkerProtocol';
 import {
   IMAGE_PANEL_TOPIC_INCLUDES,
+  topicNeedsOrderedVideoFrames,
   type ImageSurfaceStatus,
 } from './core/imageTypes';
-import { repairH264Seek } from './core/h264SeekRepair';
+import { executeH264Bootstrap } from './core/h264SeekRepair';
 import { isH264MessageEvent, toWorkerFrame } from './core/messageFrameAdapter';
 import { applyDepthTopicPreset } from './core/depthColorDefaults';
 import type { ImageConfig } from './defaults';
@@ -78,11 +79,17 @@ export const ImagePanel: React.FC<ImagePanelProps> = (props) => {
   const lastPlaybackTimeNsRef = useRef<bigint | null>(null);
   const h264SeekRepairAbortRef = useRef<AbortController | null>(null);
   const lastUiStatusRef = useRef<ImageSurfaceStatus>({ phase: 'idle' });
-  const h264ModeRef = useRef(false);
+  const h264OrderedModeRef = useRef(false);
+  const h264BootstrapInFlightRef = useRef(false);
+  const h264BootstrapGenerationRef = useRef(0);
+  const h264BufferedLiveRef = useRef<RosMessageEvent[]>([]);
+  const consumerModeRef = useRef<'latest' | 'all'>('latest');
   const [status, setStatus] = useState<ImageSurfaceStatus>({ phase: 'idle' });
   const [metrics, setMetrics] = useState<ImageRenderMetrics | null>(null);
-  const mainConsumerId = `${panelId}:image-main`;
-  const h264ConsumerId = `${panelId}:image-main-h264`;
+  const imageConsumerId = `${panelId}:image-main`;
+  const topicSchema = useMessagePipeline((state) =>
+    state.playerState.activeData?.topics.find((entry) => entry.name === topic)?.type ?? '',
+  );
 
   // Worker lifecycle: init on mount, dispose on unmount
   useEffect(() => {
@@ -199,8 +206,8 @@ export const ImagePanel: React.FC<ImagePanelProps> = (props) => {
   }, [formatMessage]);
 
   // High-frequency image frames bypass messageBus. Still images/raw frames use
-  // latest-only; H.264 switches to an ordered lane after the first keyframe-like
-  // sample so delta frames are not dropped.
+  // latest-only; ordered video codecs use mode=all from registration and bootstrap
+  // the nearest decodable GOP before accepting live delta frames.
   useEffect(() => {
     if (!topic) {
       return;
@@ -209,51 +216,160 @@ export const ImagePanel: React.FC<ImagePanelProps> = (props) => {
     if (!worker) {
       return;
     }
-    h264ModeRef.current = false;
+
+    h264OrderedModeRef.current = false;
+    h264BootstrapInFlightRef.current = false;
+    h264BootstrapGenerationRef.current += 1;
+    h264BufferedLiveRef.current = [];
+    consumerModeRef.current = 'latest';
     setMetrics(null);
     worker.postMessage({ type: 'reset' } satisfies ImageRenderWorkerRequest);
-    player.registerHighFrequencyConsumer(mainConsumerId, {
-      topic,
-      lane: 'video',
-      mode: 'latest',
-      onLatestMessage: (message) => {
-        if (isH264MessageEvent(message)) {
-          if (h264ModeRef.current) {
-            return;
-          }
-          h264ModeRef.current = true;
-          player.registerHighFrequencyConsumer(h264ConsumerId, {
-            topic,
-            lane: 'video',
-            mode: 'all',
-            onMessageBatch: (messages) => {
-              for (const event of messages) {
-                if (isH264MessageEvent(event)) {
-                  postImageFrame(worker, event);
-                }
-              }
-            },
-          });
+
+    const initialOrdered = topicNeedsOrderedVideoFrames(topicSchema);
+    if (initialOrdered) {
+      h264OrderedModeRef.current = true;
+      consumerModeRef.current = 'all';
+    }
+
+    const handleH264Frame = (event: RosMessageEvent) => {
+      if (h264BootstrapInFlightRef.current) {
+        h264BufferedLiveRef.current.push(event);
+        return;
+      }
+      postImageFrame(worker, event);
+    };
+
+    const dispatchHighFrequencyBatch = (messages: RosMessageEvent[]) => {
+      for (const event of messages) {
+        if (isH264MessageEvent(event)) {
+          handleH264Frame(event);
+        } else {
+          postImageFrame(worker, event);
         }
-        postImageFrame(worker, message);
-      },
-      onMessageBatch: (messages) => {
-        if (h264ModeRef.current) {
+      }
+    };
+
+    const runBootstrap = async (
+      targetTime: ReturnType<Player['getCurrentTime']>,
+      preserveFrame: boolean,
+    ) => {
+      if (!targetTime) {
+        return false;
+      }
+      const generation = h264BootstrapGenerationRef.current;
+      h264BootstrapInFlightRef.current = true;
+      h264SeekRepairAbortRef.current?.abort();
+      const controller = new AbortController();
+      h264SeekRepairAbortRef.current = controller;
+
+      try {
+        const success = await executeH264Bootstrap({
+          player,
+          worker,
+          topic,
+          targetTime,
+          liveEvents: h264BufferedLiveRef.current,
+          signal: controller.signal,
+          preserveFrame,
+        });
+        if (controller.signal.aborted || generation !== h264BootstrapGenerationRef.current) {
+          return false;
+        }
+        if (success) {
+          h264BufferedLiveRef.current = [];
+        }
+        return success;
+      } finally {
+        if (generation === h264BootstrapGenerationRef.current) {
+          h264BootstrapInFlightRef.current = false;
+        }
+        if (h264SeekRepairAbortRef.current === controller) {
+          h264SeekRepairAbortRef.current = null;
+        }
+      }
+    };
+
+    const activateH264OrderedMode = async (triggerMessage?: RosMessageEvent) => {
+      if (h264OrderedModeRef.current) {
+        if (triggerMessage) {
+          handleH264Frame(triggerMessage);
+        }
+        return;
+      }
+
+      h264OrderedModeRef.current = true;
+      if (triggerMessage) {
+        h264BufferedLiveRef.current.push(triggerMessage);
+      }
+
+      if (consumerModeRef.current !== 'all') {
+        consumerModeRef.current = 'all';
+        player.unregisterHighFrequencyConsumer(imageConsumerId);
+        player.registerHighFrequencyConsumer(imageConsumerId, {
+          topic,
+          lane: 'video',
+          mode: 'all',
+          onMessageBatch: dispatchHighFrequencyBatch,
+        });
+      }
+
+      const currentTime = player.getCurrentTime();
+      if (currentTime) {
+        await runBootstrap(currentTime, false);
+      }
+    };
+
+    const handleMessage = (message: RosMessageEvent) => {
+      if (isH264MessageEvent(message)) {
+        if (!h264OrderedModeRef.current) {
+          void activateH264OrderedMode(message);
           return;
         }
-        const latest = messages.at(-1);
-        if (latest) {
-          postImageFrame(worker, latest);
-        }
-      },
-    });
+        handleH264Frame(message);
+        return;
+      }
+      postImageFrame(worker, message);
+    };
+
+    if (consumerModeRef.current === 'all') {
+      player.registerHighFrequencyConsumer(imageConsumerId, {
+        topic,
+        lane: 'video',
+        mode: 'all',
+        onMessageBatch: dispatchHighFrequencyBatch,
+      });
+      const currentTime = player.getCurrentTime();
+      if (currentTime) {
+        void runBootstrap(currentTime, false);
+      }
+    } else {
+      player.registerHighFrequencyConsumer(imageConsumerId, {
+        topic,
+        lane: 'video',
+        mode: 'latest',
+        onLatestMessage: handleMessage,
+        onMessageBatch: (messages) => {
+          if (h264OrderedModeRef.current) {
+            return;
+          }
+          const latest = messages.at(-1);
+          if (latest) {
+            handleMessage(latest);
+          }
+        },
+      });
+    }
 
     return () => {
-      player.unregisterHighFrequencyConsumer(mainConsumerId);
-      player.unregisterHighFrequencyConsumer(h264ConsumerId);
+      h264BootstrapGenerationRef.current += 1;
+      h264SeekRepairAbortRef.current?.abort();
+      h264SeekRepairAbortRef.current = null;
+      h264BufferedLiveRef.current = [];
+      h264BootstrapInFlightRef.current = false;
+      player.unregisterHighFrequencyConsumer(imageConsumerId);
       worker.postMessage({ type: 'reset' } satisfies ImageRenderWorkerRequest);
     };
-  }, [player, mainConsumerId, h264ConsumerId, topic]);
+  }, [imageConsumerId, player, topic, topicSchema]);
 
   useEffect(() => {
     return () => {
@@ -277,20 +393,39 @@ export const ImagePanel: React.FC<ImagePanelProps> = (props) => {
         h264SeekRepairAbortRef.current?.abort();
         h264SeekRepairAbortRef.current = null;
         const worker = workerRef.current;
-        if (worker && topic && h264ModeRef.current) {
+        if (worker && topic && h264OrderedModeRef.current) {
+          h264BootstrapInFlightRef.current = true;
+          h264BufferedLiveRef.current = [];
+          const generation = h264BootstrapGenerationRef.current;
           const controller = new AbortController();
           h264SeekRepairAbortRef.current = controller;
-          worker.postMessage({
-            type: 'reset',
-            preserveFrame: true,
-          } satisfies ImageRenderWorkerRequest);
-          void repairH264Seek(player, worker, topic, time, {
-            signal: controller.signal,
-          }).finally(() => {
-            if (h264SeekRepairAbortRef.current === controller) {
-              h264SeekRepairAbortRef.current = null;
+          void (async () => {
+            try {
+              const success = await executeH264Bootstrap({
+                player,
+                worker,
+                topic,
+                targetTime: time,
+                liveEvents: h264BufferedLiveRef.current,
+                signal: controller.signal,
+                preserveFrame: true,
+              });
+              if (
+                success &&
+                !controller.signal.aborted &&
+                generation === h264BootstrapGenerationRef.current
+              ) {
+                h264BufferedLiveRef.current = [];
+              }
+            } finally {
+              if (generation === h264BootstrapGenerationRef.current) {
+                h264BootstrapInFlightRef.current = false;
+              }
+              if (h264SeekRepairAbortRef.current === controller) {
+                h264SeekRepairAbortRef.current = null;
+              }
             }
-          });
+          })();
         } else {
           workerRef.current?.postMessage({ type: 'reset' } satisfies ImageRenderWorkerRequest);
         }

--- a/src/features/panels/Image/core/ImageRender.worker.ts
+++ b/src/features/panels/Image/core/ImageRender.worker.ts
@@ -46,6 +46,7 @@ import type {
   ImageWorkerFrameEnvelope,
 } from './imageWorkerProtocol';
 import type { RawImageDecodeOptions } from './imageColorMode';
+import { H264_SEEK_MAX_FRAMES } from './h264SeekRepair';
 
 const DEFAULT_RENDER_OPTIONS: ImageRenderOptions = {
   backgroundColor: '#000000',
@@ -399,6 +400,10 @@ class ImageRenderWorkerRuntime {
         }
         return;
 
+      case 'bootstrapH264':
+        this.#bootstrapH264(message.frames, message.preserveFrame === true);
+        return;
+
       case 'reset':
         this.#epoch += 1;
         this.#pendingFrame = null;
@@ -431,11 +436,42 @@ class ImageRenderWorkerRuntime {
     }
   }
 
-  #enqueueFrame(frame: ImageWorkerFrameEnvelope): void {
-    if (!isH264Frame(frame)) {
-      this.#pendingFrame = frame;
+  #bootstrapH264(frames: ImageWorkerFrameEnvelope[], preserveFrame: boolean): void {
+    this.#epoch += 1;
+    this.#pendingFrame = null;
+    this.#pendingH264Frames = [];
+    this.#disposePendingH264Output();
+    this.#haltUntilReset = false;
+    this.#resetH264RuntimeState();
+    this.#decoder.reset();
+    if (!preserveFrame) {
+      this.#disposeCachedBitmap();
+      this.#cachedFrame = null;
+      this.#clearCanvas();
+      this.#emitStatus({ phase: 'idle' });
+    }
+
+    const h264Frames = frames.filter(isH264Frame).slice(0, H264_SEEK_MAX_FRAMES);
+    if (h264Frames.length === 0 || !h264Frames.some((frame) => containsH264IdrNal(frame.data))) {
+      this.#h264WaitingForIdr = true;
+      this.#emitMetricsIfDue(true);
       return;
     }
+
+    for (const frame of h264Frames) {
+      this.#enqueueH264Frame(frame, { applyBackpressure: false });
+    }
+
+    this.#emitMetricsIfDue(true);
+    if (!this.#isProcessing) {
+      void this.#drainLatestFrame();
+    }
+  }
+
+  #enqueueH264Frame(
+    frame: ImageWorkerFrameEnvelope,
+    options: { applyBackpressure?: boolean } = {},
+  ): void {
     this.#h264RecentConfig = updateH264ConfigPackets(this.#h264RecentConfig, frame);
     if (this.#h264WaitingForIdr && !containsH264IdrNal(frame.data)) {
       if (isH264ConfigOnly(frame.data)) {
@@ -446,7 +482,9 @@ class ImageRenderWorkerRuntime {
         return;
       }
       this.#droppedH264Frames += 1;
-      this.#emitMetricsIfDue();
+      if (options.applyBackpressure !== false) {
+        this.#emitMetricsIfDue();
+      }
       return;
     }
     if (containsH264IdrNal(frame.data)) {
@@ -457,9 +495,19 @@ class ImageRenderWorkerRuntime {
       }
     }
     this.#pendingH264Frames.push(frame);
-    this.#updateH264Pressure();
-    this.#trimPendingH264FramesIfNeeded();
-    this.#emitMetricsIfDue();
+    if (options.applyBackpressure !== false) {
+      this.#updateH264Pressure();
+      this.#trimPendingH264FramesIfNeeded();
+      this.#emitMetricsIfDue();
+    }
+  }
+
+  #enqueueFrame(frame: ImageWorkerFrameEnvelope): void {
+    if (!isH264Frame(frame)) {
+      this.#pendingFrame = frame;
+      return;
+    }
+    this.#enqueueH264Frame(frame);
   }
 
   #trimPendingH264FramesIfNeeded(): void {

--- a/src/features/panels/Image/core/h264SeekRepair.test.ts
+++ b/src/features/panels/Image/core/h264SeekRepair.test.ts
@@ -3,8 +3,13 @@ import type { Player } from '@/core/types/player';
 import type { MessageEvent as RosMessageEvent } from '@/core/types/ros';
 import {
   H264_SEEK_MAX_FRAMES,
+  bootstrapH264FromTime,
+  dedupeH264MessageEventsByReceiveTime,
+  executeH264Bootstrap,
   findLatestH264KeyFrameIndex,
+  mergeH264BootstrapWithLiveFrames,
   repairH264Seek,
+  selectH264BootstrapFrames,
   selectH264SeekRepairFrames,
 } from './h264SeekRepair';
 
@@ -26,6 +31,40 @@ function makeEvent(sec: number, data: Uint8Array, format = 'h264'): RosMessageEv
 }
 
 describe('h264SeekRepair', () => {
+  it('selectH264BootstrapFrames uses the first IDR when the playhead is before it', () => {
+    const messages = [
+      makeEvent(0, deltaChunk),
+      makeEvent(0, keyChunk),
+      makeEvent(0, deltaChunk),
+    ];
+    messages[0]!.receiveTime = { sec: 0, nsec: 0 };
+    messages[1]!.receiveTime = { sec: 0, nsec: 33_378_000 };
+    messages[2]!.receiveTime = { sec: 0, nsec: 66_600_000 };
+
+    expect(selectH264SeekRepairFrames(messages, { sec: 0, nsec: 0 })).toEqual([]);
+
+    const bootstrap = selectH264BootstrapFrames(messages, { sec: 0, nsec: 0 });
+    expect(bootstrap).toHaveLength(1);
+    expect(bootstrap[0]?.receiveTime.nsec).toBe(33_378_000);
+  });
+
+  it('selects the 33ms IDR GOP at file start for an early playhead target', () => {
+    const messages = [
+      makeEvent(0, deltaChunk),
+      makeEvent(0, keyChunk),
+      makeEvent(0, deltaChunk),
+    ];
+    messages[0]!.receiveTime = { sec: 0, nsec: 0 };
+    messages[1]!.receiveTime = { sec: 0, nsec: 33_378_000 };
+    messages[2]!.receiveTime = { sec: 0, nsec: 66_600_000 };
+
+    const repair = selectH264SeekRepairFrames(messages, { sec: 0, nsec: 66_600_000 });
+
+    expect(repair).toHaveLength(2);
+    expect(repair[0]?.receiveTime.nsec).toBe(33_378_000);
+    expect(repair[1]?.receiveTime.nsec).toBe(66_600_000);
+  });
+
   it('findLatestH264KeyFrameIndex returns the last keyframe index', () => {
     const messages = [makeEvent(1, keyChunk), makeEvent(2, deltaChunk), makeEvent(3, deltaChunk)];
     expect(findLatestH264KeyFrameIndex(messages)).toBe(0);
@@ -118,17 +157,15 @@ describe('h264SeekRepair', () => {
     expect(repair.at(-1)?.receiveTime.sec).toBe(H264_SEEK_MAX_FRAMES);
   });
 
-  it('posts at most 180 frame messages for a long-GOP seek repair', async () => {
+  it('posts a single bootstrapH264 message for a long-GOP seek repair', async () => {
     const messages = [
       makeEvent(1, keyChunk),
       ...Array.from({ length: 1_000 }, (_, index) => makeEvent(index + 2, deltaChunk)),
     ];
-    let framePosts = 0;
+    const posts: unknown[] = [];
     const worker = {
-      postMessage(request: { type?: string }) {
-        if (request.type === 'frame') {
-          framePosts += 1;
-        }
+      postMessage(request: unknown) {
+        posts.push(request);
       },
     } as unknown as Worker;
     const player = {
@@ -138,7 +175,9 @@ describe('h264SeekRepair', () => {
     await expect(
       repairH264Seek(player, worker, '/camera/video', { sec: 2_000, nsec: 0 }),
     ).resolves.toBe(true);
-    expect(framePosts).toBe(H264_SEEK_MAX_FRAMES);
+    expect(posts).toHaveLength(1);
+    expect((posts[0] as { type?: string }).type).toBe('bootstrapH264');
+    expect((posts[0] as { frames?: unknown[] }).frames).toHaveLength(H264_SEEK_MAX_FRAMES);
   });
 
   it('keeps range-query payloads borrowed while posting seek-repair frames', async () => {
@@ -149,8 +188,8 @@ describe('h264SeekRepair', () => {
     const worker = {
       postMessage(request: unknown, transfer: Transferable[] = []) {
         const cloned = structuredClone(request, { transfer });
-        if ((cloned as { type?: string }).type === 'frame') {
-          postedFrames.push(cloned);
+        if ((cloned as { type?: string }).type === 'bootstrapH264') {
+          postedFrames.push(...((cloned as { frames?: unknown[] }).frames ?? []));
         }
       },
     } as unknown as Worker;
@@ -169,7 +208,7 @@ describe('h264SeekRepair', () => {
     expect(deltaPayload.byteLength).toBeGreaterThan(0);
   });
 
-  it('does not reset or post frames when an in-flight repair is aborted', async () => {
+  it('does not post frames when an in-flight repair is aborted', async () => {
     let resolveMessages: ((messages: RosMessageEvent[]) => void) | undefined;
     const messagesPromise = new Promise<RosMessageEvent[]>((resolve) => {
       resolveMessages = resolve;
@@ -193,5 +232,73 @@ describe('h264SeekRepair', () => {
 
     await expect(repair).resolves.toBe(false);
     expect(posts).toEqual([]);
+  });
+
+  it('merges bootstrap and live frames by receive time without duplicates', () => {
+    const bootstrap = [makeEvent(1, keyChunk), makeEvent(2, deltaChunk)];
+    const live = [makeEvent(2, deltaChunk), makeEvent(3, deltaChunk)];
+    const merged = mergeH264BootstrapWithLiveFrames(bootstrap, live);
+    expect(merged.map((event) => event.receiveTime.sec)).toEqual([1, 2, 3]);
+    expect(merged).toHaveLength(3);
+  });
+
+  it('dedupes messages that share the same receive time', () => {
+    const duplicate = [makeEvent(1, keyChunk), makeEvent(1, deltaChunk)];
+    expect(dedupeH264MessageEventsByReceiveTime(duplicate)).toHaveLength(1);
+  });
+
+  it('executeH264Bootstrap rejects batches without an IDR frame', async () => {
+    const posts: unknown[] = [];
+    const worker = {
+      postMessage(request: unknown) {
+        posts.push(request);
+      },
+    } as unknown as Worker;
+    const player = {
+      getMessagesInTimeRange: async () => [],
+    } as unknown as Player;
+
+    await expect(
+      executeH264Bootstrap({
+        player,
+        worker,
+        topic: '/camera/video',
+        targetTime: { sec: 0, nsec: 0 },
+        liveEvents: [makeEvent(0, deltaChunk)],
+      }),
+    ).resolves.toBe(false);
+    expect(posts).toEqual([]);
+  });
+
+  it('executeH264Bootstrap uses live frame coverage when bootstrapping before the first IDR', async () => {
+    const messages = [
+      makeEvent(0, deltaChunk),
+      makeEvent(0, keyChunk),
+      makeEvent(0, deltaChunk),
+    ];
+    messages[0]!.receiveTime = { sec: 0, nsec: 0 };
+    messages[1]!.receiveTime = { sec: 0, nsec: 33_378_000 };
+    messages[2]!.receiveTime = { sec: 0, nsec: 66_600_000 };
+    const posts: unknown[] = [];
+    const worker = {
+      postMessage(request: unknown) {
+        posts.push(request);
+      },
+    } as unknown as Worker;
+    const player = {
+      getMessagesInTimeRange: async () => messages,
+    } as unknown as Player;
+
+    await expect(
+      executeH264Bootstrap({
+        player,
+        worker,
+        topic: '/camera/video',
+        targetTime: { sec: 0, nsec: 0 },
+        liveEvents: [messages[2]!],
+      }),
+    ).resolves.toBe(true);
+    expect(posts).toHaveLength(1);
+    expect((posts[0] as { frames?: unknown[] }).frames).toHaveLength(2);
   });
 });

--- a/src/features/panels/Image/core/h264SeekRepair.test.ts
+++ b/src/features/panels/Image/core/h264SeekRepair.test.ts
@@ -3,7 +3,6 @@ import type { Player } from '@/core/types/player';
 import type { MessageEvent as RosMessageEvent } from '@/core/types/ros';
 import {
   H264_SEEK_MAX_FRAMES,
-  bootstrapH264FromTime,
   dedupeH264MessageEventsByReceiveTime,
   executeH264Bootstrap,
   findLatestH264KeyFrameIndex,
@@ -19,8 +18,13 @@ const spsChunk = new Uint8Array([0, 0, 1, 0x67, 0x42, 0, 0x1e]);
 const ppsChunk = new Uint8Array([0, 0, 1, 0x68, 0xce, 0x3c]);
 const idrChunk = new Uint8Array([0, 0, 1, 0x65, 3, 4]);
 
-function makeEvent(sec: number, data: Uint8Array, format = 'h264'): RosMessageEvent {
-  const receiveTime = { sec, nsec: 0 };
+function makeEvent(
+  sec: number,
+  data: Uint8Array,
+  format = 'h264',
+  nsec = 0,
+): RosMessageEvent {
+  const receiveTime = { sec, nsec };
   return {
     topic: '/camera/video',
     receiveTime,
@@ -30,16 +34,17 @@ function makeEvent(sec: number, data: Uint8Array, format = 'h264'): RosMessageEv
   };
 }
 
+function makeFileStartGopMessages(): RosMessageEvent[] {
+  return [
+    makeEvent(0, deltaChunk, 'h264', 0),
+    makeEvent(0, keyChunk, 'h264', 33_378_000),
+    makeEvent(0, deltaChunk, 'h264', 66_600_000),
+  ];
+}
+
 describe('h264SeekRepair', () => {
   it('selectH264BootstrapFrames uses the first IDR when the playhead is before it', () => {
-    const messages = [
-      makeEvent(0, deltaChunk),
-      makeEvent(0, keyChunk),
-      makeEvent(0, deltaChunk),
-    ];
-    messages[0]!.receiveTime = { sec: 0, nsec: 0 };
-    messages[1]!.receiveTime = { sec: 0, nsec: 33_378_000 };
-    messages[2]!.receiveTime = { sec: 0, nsec: 66_600_000 };
+    const messages = makeFileStartGopMessages();
 
     expect(selectH264SeekRepairFrames(messages, { sec: 0, nsec: 0 })).toEqual([]);
 
@@ -49,14 +54,7 @@ describe('h264SeekRepair', () => {
   });
 
   it('selects the 33ms IDR GOP at file start for an early playhead target', () => {
-    const messages = [
-      makeEvent(0, deltaChunk),
-      makeEvent(0, keyChunk),
-      makeEvent(0, deltaChunk),
-    ];
-    messages[0]!.receiveTime = { sec: 0, nsec: 0 };
-    messages[1]!.receiveTime = { sec: 0, nsec: 33_378_000 };
-    messages[2]!.receiveTime = { sec: 0, nsec: 66_600_000 };
+    const messages = makeFileStartGopMessages();
 
     const repair = selectH264SeekRepairFrames(messages, { sec: 0, nsec: 66_600_000 });
 
@@ -271,14 +269,11 @@ describe('h264SeekRepair', () => {
   });
 
   it('executeH264Bootstrap uses live frame coverage when bootstrapping before the first IDR', async () => {
-    const messages = [
-      makeEvent(0, deltaChunk),
-      makeEvent(0, keyChunk),
-      makeEvent(0, deltaChunk),
-    ];
-    messages[0]!.receiveTime = { sec: 0, nsec: 0 };
-    messages[1]!.receiveTime = { sec: 0, nsec: 33_378_000 };
-    messages[2]!.receiveTime = { sec: 0, nsec: 66_600_000 };
+    const messages = makeFileStartGopMessages();
+    const latestLiveFrame = messages[2];
+    if (!latestLiveFrame) {
+      throw new Error('expected a third bootstrap message');
+    }
     const posts: unknown[] = [];
     const worker = {
       postMessage(request: unknown) {
@@ -295,7 +290,7 @@ describe('h264SeekRepair', () => {
         worker,
         topic: '/camera/video',
         targetTime: { sec: 0, nsec: 0 },
-        liveEvents: [messages[2]!],
+        liveEvents: [latestLiveFrame],
       }),
     ).resolves.toBe(true);
     expect(posts).toHaveLength(1);

--- a/src/features/panels/Image/core/h264SeekRepair.ts
+++ b/src/features/panels/Image/core/h264SeekRepair.ts
@@ -3,7 +3,7 @@ import type { MessageEvent as RosMessageEvent, Time } from '@/core/types/ros';
 import { addMs, toNano } from '@/shared/utils/time';
 import { containsH264IdrNal } from './h264';
 import { selectLatestCompleteH264Gop } from './h264Queue';
-import type { ImageRenderWorkerRequest } from './imageWorkerProtocol';
+import type { ImageRenderWorkerRequest, ImageWorkerFrameEnvelope } from './imageWorkerProtocol';
 import { getH264MessagePayload, isH264MessageEvent, toWorkerFrame } from './messageFrameAdapter';
 
 /** Progressive lookback windows when searching for a keyframe before a seek target. */
@@ -11,6 +11,59 @@ export const H264_SEEK_WINDOWS_MS = [2000, 5000, 10_000, 30_000] as const;
 
 /** Maximum frame messages posted for one seek repair. */
 export const H264_SEEK_MAX_FRAMES = 180;
+
+/** Forward read when bootstrapping at/before the file's first IDR. */
+export const H264_BOOTSTRAP_FORWARD_MS = 2_000;
+
+function maxReceiveTime(a: Time, b: Time): Time {
+  return toNano(a) >= toNano(b) ? a : b;
+}
+
+function compareReceiveTime(a: RosMessageEvent, b: RosMessageEvent): number {
+  const diff = toNano(a.receiveTime) - toNano(b.receiveTime);
+  if (diff < 0n) {
+    return -1;
+  }
+  if (diff > 0n) {
+    return 1;
+  }
+  return 0;
+}
+
+function sortByReceiveTime(messages: RosMessageEvent[]): RosMessageEvent[] {
+  return [...messages].sort(compareReceiveTime);
+}
+
+export function maxH264MessageReceiveTime(messages: RosMessageEvent[]): Time | undefined {
+  let latest: Time | undefined;
+  for (const event of messages) {
+    if (!isH264MessageEvent(event)) {
+      continue;
+    }
+    if (!latest || toNano(event.receiveTime) > toNano(latest)) {
+      latest = event.receiveTime;
+    }
+  }
+  return latest;
+}
+
+export function findFirstH264IdrReceiveTime(messages: RosMessageEvent[]): Time | undefined {
+  for (const event of sortByReceiveTime(messages.filter(isH264MessageEvent))) {
+    const payload = getH264MessagePayload(event);
+    if (payload && containsH264IdrNal(payload)) {
+      return event.receiveTime;
+    }
+  }
+  return undefined;
+}
+
+export function preparedBootstrapContainsIdr(
+  frames: readonly ImageWorkerFrameEnvelope[],
+): boolean {
+  return frames.some(
+    (frame) => frame.kind === 'compressed' && containsH264IdrNal(frame.data),
+  );
+}
 
 export function findLatestH264KeyFrameIndex(messages: RosMessageEvent[]): number {
   for (let i = messages.length - 1; i >= 0; i -= 1) {
@@ -31,18 +84,9 @@ export function selectH264SeekRepairFrames(
   targetTime: Time,
 ): RosMessageEvent[] {
   const targetNs = toNano(targetTime);
-  const h264Messages = messages
-    .filter((event) => isH264MessageEvent(event) && toNano(event.receiveTime) <= targetNs)
-    .sort((a, b) => {
-      const diff = toNano(a.receiveTime) - toNano(b.receiveTime);
-      if (diff < 0n) {
-        return -1;
-      }
-      if (diff > 0n) {
-        return 1;
-      }
-      return 0;
-    });
+  const h264Messages = sortByReceiveTime(
+    messages.filter((event) => isH264MessageEvent(event) && toNano(event.receiveTime) <= targetNs),
+  );
 
   const candidates = h264Messages.flatMap((event) => {
     const data = getH264MessagePayload(event);
@@ -54,6 +98,30 @@ export function selectH264SeekRepairFrames(
 
   return limitH264SeekRepairFrames(selectLatestCompleteH264Gop(candidates).frames)
     .map(({ event }) => event);
+}
+
+/**
+ * Bootstrap selection for an arbitrary playhead. Falls back to the file's first
+ * IDR when the target time is still before the initial random-access point.
+ */
+export function selectH264BootstrapFrames(
+  messages: RosMessageEvent[],
+  targetTime: Time,
+  options: { coverageEndTime?: Time } = {},
+): RosMessageEvent[] {
+  const seekRepair = selectH264SeekRepairFrames(messages, targetTime);
+  if (seekRepair.length > 0) {
+    return seekRepair;
+  }
+
+  const firstIdrTime = findFirstH264IdrReceiveTime(messages);
+  if (!firstIdrTime) {
+    return [];
+  }
+
+  const coverageEnd = options.coverageEndTime ?? targetTime;
+  const effectiveEnd = maxReceiveTime(maxReceiveTime(coverageEnd, targetTime), firstIdrTime);
+  return selectH264SeekRepairFrames(messages, effectiveEnd);
 }
 
 export function limitH264SeekRepairFrames<T extends { data: Uint8Array }>(
@@ -68,52 +136,200 @@ export function limitH264SeekRepairFrames<T extends { data: Uint8Array }>(
   return frames.slice(0, H264_SEEK_MAX_FRAMES);
 }
 
-export async function repairH264Seek(
+export function receiveTimeKey(time: Time): string {
+  return `${time.sec}:${time.nsec}`;
+}
+
+export function dedupeH264MessageEventsByReceiveTime(
+  messages: RosMessageEvent[],
+): RosMessageEvent[] {
+  const seen = new Set<string>();
+  const deduped: RosMessageEvent[] = [];
+  for (const event of messages) {
+    const key = receiveTimeKey(event.receiveTime);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(event);
+  }
+  return deduped;
+}
+
+export function mergeH264BootstrapWithLiveFrames(
+  bootstrapEvents: RosMessageEvent[],
+  liveEvents: RosMessageEvent[],
+): RosMessageEvent[] {
+  return dedupeH264MessageEventsByReceiveTime(
+    sortByReceiveTime([...bootstrapEvents, ...liveEvents]),
+  );
+}
+
+export function toWorkerFramesFromEvents(
+  events: RosMessageEvent[],
+  options: { transferOwnership?: boolean } = {},
+): { frames: ImageWorkerFrameEnvelope[]; transfer: Transferable[] } {
+  const frames: ImageWorkerFrameEnvelope[] = [];
+  const transfer: Transferable[] = [];
+  for (const event of events) {
+    const next = toWorkerFrame(event, options);
+    if (!next) {
+      continue;
+    }
+    frames.push(next.frame);
+    transfer.push(...next.transfer);
+  }
+  return { frames, transfer };
+}
+
+export async function fetchH264BootstrapFrames(
   player: Player,
-  worker: Worker,
   topic: string,
   targetTime: Time,
-  options: { signal?: AbortSignal } = {},
-): Promise<boolean> {
+  options: { signal?: AbortSignal; coverageEndTime?: Time } = {},
+): Promise<RosMessageEvent[]> {
   if (!player.getMessagesInTimeRange || options.signal?.aborted) {
-    return false;
+    return [];
   }
+
+  const coverageEnd = options.coverageEndTime ?? targetTime;
+  const queryEnd = addMs(coverageEnd, H264_BOOTSTRAP_FORWARD_MS);
 
   for (const windowMs of H264_SEEK_WINDOWS_MS) {
     const start = addMs(targetTime, -windowMs);
     const messages = await player.getMessagesInTimeRange({
       start,
-      end: targetTime,
+      end: queryEnd,
       topics: [topic],
     });
     if (options.signal?.aborted) {
-      return false;
+      return [];
     }
 
-    const repairFrames = selectH264SeekRepairFrames(
+    const repairFrames = selectH264BootstrapFrames(
       messages.filter((event) => event.topic === topic),
       targetTime,
+      { coverageEndTime: coverageEnd },
     );
-    if (repairFrames.length === 0) {
-      continue;
+    if (repairFrames.length > 0) {
+      return repairFrames;
     }
-
-    worker.postMessage({
-      type: 'reset',
-      preserveFrame: true,
-    } satisfies ImageRenderWorkerRequest);
-    for (const event of repairFrames) {
-      const next = toWorkerFrame(event);
-      if (!next) {
-        continue;
-      }
-      worker.postMessage(
-        { type: 'frame', frame: next.frame } satisfies ImageRenderWorkerRequest,
-        next.transfer,
-      );
-    }
-    return true;
   }
 
-  return false;
+  return [];
+}
+
+export function postH264Bootstrap(
+  worker: Worker,
+  frames: ImageWorkerFrameEnvelope[],
+  options: { preserveFrame?: boolean; transfer?: Transferable[] } = {},
+): boolean {
+  if (frames.length === 0 || !preparedBootstrapContainsIdr(frames)) {
+    return false;
+  }
+  worker.postMessage(
+    {
+      type: 'bootstrapH264',
+      frames,
+      preserveFrame: options.preserveFrame,
+    } satisfies ImageRenderWorkerRequest,
+    options.transfer ?? [],
+  );
+  return true;
+}
+
+export interface ExecuteH264BootstrapArgs {
+  player: Player;
+  worker: Worker;
+  topic: string;
+  targetTime: Time;
+  liveEvents?: RosMessageEvent[];
+  signal?: AbortSignal;
+  preserveFrame?: boolean;
+  transferOwnership?: boolean;
+}
+
+/** Fetch, merge, validate, and post one atomic H.264 bootstrap batch. */
+export async function executeH264Bootstrap(args: ExecuteH264BootstrapArgs): Promise<boolean> {
+  const {
+    player,
+    worker,
+    topic,
+    targetTime,
+    liveEvents = [],
+    signal,
+    preserveFrame = false,
+    transferOwnership = false,
+  } = args;
+
+  if (signal?.aborted) {
+    return false;
+  }
+
+  const coverageEnd = maxH264MessageReceiveTime(liveEvents) ?? targetTime;
+  const bootstrapEvents = await fetchH264BootstrapFrames(player, topic, targetTime, {
+    signal,
+    coverageEndTime: coverageEnd,
+  });
+  if (signal?.aborted) {
+    return false;
+  }
+
+  const mergedEvents = mergeH264BootstrapWithLiveFrames(bootstrapEvents, liveEvents);
+  if (mergedEvents.length === 0) {
+    return false;
+  }
+
+  const prepared = toWorkerFramesFromEvents(mergedEvents, { transferOwnership });
+  return postH264Bootstrap(worker, prepared.frames, {
+    preserveFrame,
+    transfer: prepared.transfer,
+  });
+}
+
+export async function bootstrapH264FromTime(
+  player: Player,
+  worker: Worker,
+  topic: string,
+  targetTime: Time,
+  options: {
+    signal?: AbortSignal;
+    preserveFrame?: boolean;
+    liveEvents?: RosMessageEvent[];
+    transferOwnership?: boolean;
+  } = {},
+): Promise<boolean> {
+  if (options.signal?.aborted) {
+    return false;
+  }
+
+  return executeH264Bootstrap({
+    player,
+    worker,
+    topic,
+    targetTime,
+    liveEvents: options.liveEvents,
+    signal: options.signal,
+    preserveFrame: options.preserveFrame,
+    transferOwnership: options.transferOwnership,
+  });
+}
+
+export async function repairH264Seek(
+  player: Player,
+  worker: Worker,
+  topic: string,
+  targetTime: Time,
+  options: { signal?: AbortSignal; liveEvents?: RosMessageEvent[] } = {},
+): Promise<boolean> {
+  if (options.signal?.aborted) {
+    return false;
+  }
+
+  return bootstrapH264FromTime(player, worker, topic, targetTime, {
+    signal: options.signal,
+    preserveFrame: true,
+    liveEvents: options.liveEvents,
+    transferOwnership: false,
+  });
 }

--- a/src/features/panels/Image/core/imageTypes.test.ts
+++ b/src/features/panels/Image/core/imageTypes.test.ts
@@ -12,6 +12,7 @@ import {
   prepareImageWorkerBytes,
   sniffCompressedMime,
   snapshotBytes,
+  topicNeedsOrderedVideoFrames,
 } from './imageTypes';
 
 describe('snapshotBytes', () => {
@@ -103,6 +104,18 @@ describe('isH264CompressedFrameMessage', () => {
       }),
     ).toBe(false);
     expect(getCompressedKind('vp9')).toBeNull();
+  });
+});
+
+describe('topicNeedsOrderedVideoFrames', () => {
+  it('returns true for foxglove CompressedVideo schemas', () => {
+    expect(topicNeedsOrderedVideoFrames('foxglove_msgs/msg/CompressedVideo')).toBe(true);
+    expect(topicNeedsOrderedVideoFrames('foxglove_msgs/msg/CompressedVideo [ros2msg]')).toBe(true);
+  });
+
+  it('returns false for JPEG/raw image schemas', () => {
+    expect(topicNeedsOrderedVideoFrames('sensor_msgs/msg/CompressedImage')).toBe(false);
+    expect(topicNeedsOrderedVideoFrames('sensor_msgs/msg/Image')).toBe(false);
   });
 });
 

--- a/src/features/panels/Image/core/imageTypes.ts
+++ b/src/features/panels/Image/core/imageTypes.ts
@@ -1,4 +1,8 @@
 import type { Time } from '@/core/types/ros';
+import {
+  matchesRosSchema,
+  ROS_MSG_FOXGLOVE_COMPRESSED_VIDEO,
+} from '@/shared/ros/rosMessageTypes';
 
 export interface RawImageMessage {
   encoding: string;
@@ -344,6 +348,21 @@ export function isRawImageTopicSchema(schemaName: string): boolean {
 
 /** Topic type tokens accepted by the Image panel topic picker. */
 export const IMAGE_PANEL_TOPIC_INCLUDES = ['image', 'CompressedImage', 'CompressedVideo'] as const;
+
+/**
+ * Whether a topic schema carries ordered video chunks (H264/H265/VP9/AV1) that
+ * must not be coalesced to latest-only during playback prefetch.
+ */
+export function topicNeedsOrderedVideoFrames(schemaName: string): boolean {
+  const trimmed = schemaName.trim();
+  if (!trimmed) {
+    return false;
+  }
+  if (matchesRosSchema(trimmed, ROS_MSG_FOXGLOVE_COMPRESSED_VIDEO)) {
+    return true;
+  }
+  return trimmed.toLowerCase().includes('compressedvideo');
+}
 
 export function isImagePanelTopicSchema(schemaName: string): boolean {
   const lower = schemaName.trim().toLowerCase();

--- a/src/features/panels/Image/core/imageWorkerProtocol.ts
+++ b/src/features/panels/Image/core/imageWorkerProtocol.ts
@@ -64,6 +64,11 @@ export type ImageRenderWorkerRequest =
       frame: ImageWorkerFrameEnvelope;
     }
   | {
+      type: 'bootstrapH264';
+      frames: ImageWorkerFrameEnvelope[];
+      preserveFrame?: boolean;
+    }
+  | {
       type: 'reset';
       preserveFrame?: boolean;
     }

--- a/tests/image-h264.spec.ts
+++ b/tests/image-h264.spec.ts
@@ -34,11 +34,20 @@ test('H.264 CompressedImage decodes without error', async ({ page }) => {
 
   await expect(page.locator('canvas')).not.toHaveCount(0, { timeout: 90_000 });
 
+  const imagePanel = page.getByTestId('image-panel');
+  if (await imagePanel.isVisible().catch(() => false)) {
+    await expect
+      .poll(
+        async () => Number(await imagePanel.getAttribute('data-h264-rendered-frames')),
+        { timeout: 5_000 },
+      )
+      .toBeGreaterThan(0);
+  }
+
   const hasDecodeFailure = await page.getByText(/decode failed|could not be decoded/i).count();
   expect(hasDecodeFailure).toBe(0);
 
   const imageStatus = page.getByTestId('image-panel-status');
-  const imagePanel = page.getByTestId('image-panel');
   if (await imagePanel.isVisible().catch(() => false)) {
     await expect(imageStatus).toBeVisible({ timeout: 90_000 });
     await expect(imageStatus).toHaveText(/\d+x\d+/);


### PR DESCRIPTION
## Summary
- Fix H.264 Image panel showing ~1s of waiting at playback start when the first IDR exists shortly after file start (e.g. 33ms in 00705.mcap).
- Replace dual latest/all consumers with a single ordered consumer and atomic GOP bootstrap via `bootstrapH264` worker message.
- Forward-read the nearest decodable IDR when the playhead is before the first keyframe; buffer live frames during bootstrap and only clear on success.

## Test plan
- [x] `npm test` (658 tests)
- [x] Manual verification with 00705.mcap — first frame appears at first IDR (~33ms), not after 1s GOP
- [x] H.264 E2E spec asserts rendered frames within 5s