### PR TITLE
fix(image): unfreeze H.264 playback on long-GOP and multi-stream recordings

### DIFF
--- a/src/features/panels/Image/ImagePanel.tsx
+++ b/src/features/panels/Image/ImagePanel.tsx
@@ -84,6 +84,8 @@ export const ImagePanel: React.FC<ImagePanelProps> = (props) => {
   const h264BootstrapGenerationRef = useRef(0);
   const h264BufferedLiveRef = useRef<RosMessageEvent[]>([]);
   const consumerModeRef = useRef<'latest' | 'all'>('latest');
+  /** Set by the subscription effect so worker-driven bootstrap requests can reuse it. */
+  const requestH264BootstrapRef = useRef<(() => void) | null>(null);
   const [status, setStatus] = useState<ImageSurfaceStatus>({ phase: 'idle' });
   const [metrics, setMetrics] = useState<ImageRenderMetrics | null>(null);
   const imageConsumerId = `${panelId}:image-main`;
@@ -140,6 +142,10 @@ export const ImagePanel: React.FC<ImagePanelProps> = (props) => {
       const data = event.data as ImageRenderWorkerEvent;
       if (data.type === 'metrics') {
         setMetrics(data.metrics);
+        return;
+      }
+      if (data.type === 'needsBootstrap') {
+        requestH264BootstrapRef.current?.();
         return;
       }
       if (data.type !== 'status') {
@@ -289,6 +295,21 @@ export const ImagePanel: React.FC<ImagePanelProps> = (props) => {
       }
     };
 
+    // The worker asks for this when it cannot resume from the frames it holds
+    // (broken reference chain, decoder error, or discarded backlog). Recordings
+    // with multi-second keyframe intervals — or a single IDR for the whole file —
+    // would otherwise stay frozen waiting for a random-access point.
+    requestH264BootstrapRef.current = () => {
+      if (!h264OrderedModeRef.current || h264BootstrapInFlightRef.current) {
+        return;
+      }
+      const currentTime = player.getCurrentTime();
+      if (!currentTime) {
+        return;
+      }
+      void runBootstrap(currentTime, true);
+    };
+
     const activateH264OrderedMode = async (triggerMessage?: RosMessageEvent) => {
       if (h264OrderedModeRef.current) {
         if (triggerMessage) {
@@ -366,6 +387,7 @@ export const ImagePanel: React.FC<ImagePanelProps> = (props) => {
       h264SeekRepairAbortRef.current = null;
       h264BufferedLiveRef.current = [];
       h264BootstrapInFlightRef.current = false;
+      requestH264BootstrapRef.current = null;
       player.unregisterHighFrequencyConsumer(imageConsumerId);
       worker.postMessage({ type: 'reset' } satisfies ImageRenderWorkerRequest);
     };
@@ -485,6 +507,7 @@ export const ImagePanel: React.FC<ImagePanelProps> = (props) => {
       data-h264-media-lag-ms={metrics?.mediaLagMs}
       data-h264-resync-count={metrics?.resyncCount}
       data-h264-rendered-frames={metrics?.renderedFrames}
+      data-h264-waiting-for-idr={metrics ? String(metrics.waitingForIdr) : undefined}
     >
       <PanelTopicBar className="border-zinc-800 bg-zinc-950">
         <TopicQuickPicker
@@ -529,6 +552,9 @@ function getStatusText(status: ImageSurfaceStatus): string | null {
   }
   if (status.phase === 'error') {
     return status.message ?? 'Image decode failed';
+  }
+  if (status.phase === 'stalled') {
+    return status.message ?? 'Video stalled — recovering';
   }
   if (status.phase === 'decoding' && !status.width && !status.height) {
     return 'Decoding latest frame...';

--- a/src/features/panels/Image/core/ImageRender.worker.ts
+++ b/src/features/panels/Image/core/ImageRender.worker.ts
@@ -18,7 +18,8 @@ import {
   decodedFrameLatenessMs,
   initialH264PressureState,
   isH264HardLimitExceeded,
-  shouldDropDecodedH264Frame,
+  isH264StreamDiscontinuity,
+  isSupersededH264Output,
   updateDecodeDurationEwma,
   updateH264Pressure,
   type H264PressureState,
@@ -82,6 +83,16 @@ const DEFAULT_VIEWPORT: ImageViewport = {
 const OUTPUT_TIMEOUT_MS = 5000;
 const METRICS_INTERVAL_MS = 1000;
 const H264_RESYNC_COOLDOWN_MS = 200;
+/** Minimum spacing between bootstrap requests sent to the panel. */
+const H264_BOOTSTRAP_REQUEST_COOLDOWN_MS = 1500;
+/**
+ * How long the worker waits for an in-band IDR before asking the panel to
+ * bootstrap from the nearest preceding one. Streams with a single IDR, or with a
+ * keyframe interval of several seconds, would otherwise stay blank indefinitely.
+ */
+const H264_IDR_WAIT_TIMEOUT_MS = 500;
+/** How long a stalled H.264 panel stays silent before reporting the stall. */
+const H264_STALL_REPORT_MS = 4000;
 
 // ---------- H.264 decoder ----------
 
@@ -94,6 +105,7 @@ class WorkerH264Decoder {
   #submitted = new Map<number, {
     frame: ImageWorkerFrameEnvelope;
     startedAt: number;
+    queueDepth: number;
     generation: number;
   }>();
   #callbacks: {
@@ -165,6 +177,7 @@ class WorkerH264Decoder {
       this.#submitted.set(timestamp, {
         frame,
         startedAt: performance.now(),
+        queueDepth: decoder.decodeQueueSize,
         generation,
       });
     }
@@ -233,7 +246,11 @@ class WorkerH264Decoder {
         this.#callbacks.output({
           videoFrame: frame,
           sourceFrame: submitted.frame,
-          decodeMs: performance.now() - submitted.startedAt,
+          // Elapsed time also covers the wait behind frames already queued in
+          // the decoder, so amortise it to approximate per-frame decode cost.
+          // Without this the sample tracks pipeline latency and permanently
+          // reports overload on healthy multi-stream playback.
+          decodeMs: (performance.now() - submitted.startedAt) / (submitted.queueDepth + 1),
         });
       },
       error: (error) => {
@@ -320,9 +337,23 @@ class ImageRenderWorkerRuntime {
   #h264Pressure: H264PressureState = initialH264PressureState();
   #h264DecodeMs = 0;
   #h264WaitingForIdr = false;
+  #h264WaitingForIdrSince: number | null = null;
   #h264ConfigBeforeIdr: ImageWorkerFrameEnvelope[] = [];
   #h264RecentConfig: ImageWorkerFrameEnvelope[] = [];
   #h264NeedsResync = false;
+  /**
+   * Leading `#pendingH264Frames` entries that form an in-flight bootstrap GOP.
+   * They are a dependency chain that cannot be shortened, so backpressure must
+   * never discard them; doing so throws away the only decodable prefix and
+   * leaves the panel waiting for a random-access point it already had.
+   */
+  #h264ProtectedQueueCount = 0;
+  #h264LastEnqueuedTimeNs: bigint | null = null;
+  #h264FrameIntervalMs = 0;
+  #lastH264BootstrapRequestAt = -Infinity;
+  /** Wall clock of the last visible H.264 progress, used by the stall watchdog. */
+  #h264ProgressAt: number | null = null;
+  #h264StallReported = false;
   #lastH264RenderAt = -Infinity;
   #lastH264BitmapAt = -Infinity;
   #droppedH264Frames = 0;
@@ -387,6 +418,7 @@ class ImageRenderWorkerRuntime {
         this.#isPlaying = message.isPlaying;
         this.#updateH264Pressure();
         this.#trimPendingH264FramesIfNeeded();
+        this.#reportH264StallIfDue();
         this.#emitMetricsIfDue();
         return;
 
@@ -408,6 +440,7 @@ class ImageRenderWorkerRuntime {
         this.#epoch += 1;
         this.#pendingFrame = null;
         this.#pendingH264Frames = [];
+        this.#h264ProtectedQueueCount = 0;
         this.#disposePendingH264Output();
         this.#haltUntilReset = false;
         this.#resetH264RuntimeState();
@@ -425,6 +458,7 @@ class ImageRenderWorkerRuntime {
         this.#epoch += 1;
         this.#pendingFrame = null;
         this.#pendingH264Frames = [];
+        this.#h264ProtectedQueueCount = 0;
         this.#disposePendingH264Output();
         this.#haltUntilReset = false;
         this.#decoder.dispose();
@@ -440,6 +474,7 @@ class ImageRenderWorkerRuntime {
     this.#epoch += 1;
     this.#pendingFrame = null;
     this.#pendingH264Frames = [];
+    this.#h264ProtectedQueueCount = 0;
     this.#disposePendingH264Output();
     this.#haltUntilReset = false;
     this.#resetH264RuntimeState();
@@ -453,7 +488,7 @@ class ImageRenderWorkerRuntime {
 
     const h264Frames = frames.filter(isH264Frame).slice(0, H264_SEEK_MAX_FRAMES);
     if (h264Frames.length === 0 || !h264Frames.some((frame) => containsH264IdrNal(frame.data))) {
-      this.#h264WaitingForIdr = true;
+      this.#beginWaitForH264Idr();
       this.#emitMetricsIfDue(true);
       return;
     }
@@ -461,6 +496,7 @@ class ImageRenderWorkerRuntime {
     for (const frame of h264Frames) {
       this.#enqueueH264Frame(frame, { applyBackpressure: false });
     }
+    this.#h264ProtectedQueueCount = this.#pendingH264Frames.length;
 
     this.#emitMetricsIfDue(true);
     if (!this.#isProcessing) {
@@ -472,7 +508,11 @@ class ImageRenderWorkerRuntime {
     frame: ImageWorkerFrameEnvelope,
     options: { applyBackpressure?: boolean } = {},
   ): void {
+    const live = options.applyBackpressure !== false;
     this.#h264RecentConfig = updateH264ConfigPackets(this.#h264RecentConfig, frame);
+    if (live) {
+      this.#trackH264Cadence(frame);
+    }
     if (this.#h264WaitingForIdr && !containsH264IdrNal(frame.data)) {
       if (isH264ConfigOnly(frame.data)) {
         this.#h264ConfigBeforeIdr = updateH264ConfigPackets(
@@ -482,24 +522,125 @@ class ImageRenderWorkerRuntime {
         return;
       }
       this.#droppedH264Frames += 1;
-      if (options.applyBackpressure !== false) {
+      if (live) {
+        this.#requestH264BootstrapIfIdrWaitStalled();
         this.#emitMetricsIfDue();
       }
       return;
     }
     if (containsH264IdrNal(frame.data)) {
-      this.#h264WaitingForIdr = false;
+      this.#clearWaitForH264Idr();
       if (this.#h264ConfigBeforeIdr.length > 0) {
         this.#pendingH264Frames.push(...this.#h264ConfigBeforeIdr);
         this.#h264ConfigBeforeIdr = [];
       }
     }
     this.#pendingH264Frames.push(frame);
-    if (options.applyBackpressure !== false) {
+    if (live) {
       this.#updateH264Pressure();
       this.#trimPendingH264FramesIfNeeded();
       this.#emitMetricsIfDue();
     }
+  }
+
+  /**
+   * Track the stream's frame cadence and detect breaks in it. A delta frame that
+   * follows a gap references pictures this decoder never saw (forward seek, loop
+   * wrap, or a skipped backlog), so it must not be fed to the decoder.
+   */
+  #trackH264Cadence(frame: ImageWorkerFrameEnvelope): void {
+    const frameTimeNs = timeToKey(frame.receiveTime);
+    const previousNs = this.#h264LastEnqueuedTimeNs;
+    this.#h264LastEnqueuedTimeNs = frameTimeNs;
+    if (previousNs == null) {
+      // Arm the stall watchdog from the first live frame.
+      this.#h264ProgressAt ??= performance.now();
+      return;
+    }
+    const gapMs = Number(frameTimeNs - previousNs) / 1_000_000;
+    if (gapMs <= 0) {
+      return;
+    }
+    if (
+      !containsH264IdrNal(frame.data) &&
+      isH264StreamDiscontinuity(gapMs, this.#h264FrameIntervalMs)
+    ) {
+      this.#droppedH264Frames += this.#pendingH264Frames.length;
+      this.#pendingH264Frames = [];
+      this.#h264ProtectedQueueCount = 0;
+      this.#beginWaitForH264Idr();
+      this.#resyncH264Decoder();
+      this.#requestH264Bootstrap();
+      // Leave the cadence estimate untouched so the jump does not become the
+      // baseline for the next continuity check.
+      return;
+    }
+    this.#h264FrameIntervalMs = updateDecodeDurationEwma(this.#h264FrameIntervalMs, gapMs);
+  }
+
+  #beginWaitForH264Idr(): void {
+    this.#h264WaitingForIdr = true;
+    this.#h264WaitingForIdrSince = performance.now();
+    this.#h264ConfigBeforeIdr = [...this.#h264RecentConfig];
+  }
+
+  #clearWaitForH264Idr(): void {
+    this.#h264WaitingForIdr = false;
+    this.#h264WaitingForIdrSince = null;
+  }
+
+  /**
+   * Ask the panel for a bootstrap batch starting at the nearest *preceding* IDR.
+   * Waiting for the next in-band IDR is not a recovery: recordings exist whose
+   * keyframe interval is several seconds, and others carry exactly one IDR for
+   * the whole file, so the wait can never end.
+   */
+  #requestH264Bootstrap(): void {
+    const now = performance.now();
+    if (now - this.#lastH264BootstrapRequestAt < H264_BOOTSTRAP_REQUEST_COOLDOWN_MS) {
+      return;
+    }
+    this.#lastH264BootstrapRequestAt = now;
+    workerScope.postMessage({ type: 'needsBootstrap' } satisfies ImageRenderWorkerEvent);
+  }
+
+  #requestH264BootstrapIfIdrWaitStalled(): void {
+    const since = this.#h264WaitingForIdrSince;
+    if (since == null || performance.now() - since < H264_IDR_WAIT_TIMEOUT_MS) {
+      return;
+    }
+    this.#requestH264Bootstrap();
+  }
+
+  /**
+   * Surface a stall instead of leaving a silently frozen canvas: every H.264
+   * discard path only moves a metrics counter, so without this the panel looks
+   * like a still image with no explanation.
+   */
+  #reportH264StallIfDue(): void {
+    const progressAt = this.#h264ProgressAt;
+    if (progressAt == null || !this.#isPlaying) {
+      return;
+    }
+    if (performance.now() - progressAt < H264_STALL_REPORT_MS) {
+      return;
+    }
+    if (this.#h264StallReported) {
+      return;
+    }
+    this.#h264StallReported = true;
+    console.warn(
+      `ImageRenderWorker: no H.264 frame rendered for ${H264_STALL_REPORT_MS}ms ` +
+        `(dropped=${this.#droppedH264Frames}, queue=${this.#pendingH264Frames.length}, ` +
+        `waitingForIdr=${this.#h264WaitingForIdr})`,
+    );
+    this.#emitStatus({ phase: 'stalled' });
+    this.#requestH264Bootstrap();
+  }
+
+  #noteH264Progress(): void {
+    this.#h264ProgressAt = performance.now();
+    this.#h264StallReported = false;
   }
 
   #enqueueFrame(frame: ImageWorkerFrameEnvelope): void {
@@ -511,6 +652,13 @@ class ImageRenderWorkerRuntime {
   }
 
   #trimPendingH264FramesIfNeeded(): void {
+    if (this.#h264ProtectedQueueCount > 0) {
+      // An in-flight bootstrap GOP is still draining. Its frames are a
+      // dependency chain, and a bootstrap batch legitimately exceeds the live
+      // queue bounds, so trimming here would discard the decodable prefix that
+      // was just fetched.
+      return;
+    }
     const queueSpanMs = h264QueueSpanMs(this.#pendingH264Frames);
     const hardLimitExceeded = isH264HardLimitExceeded(
       this.#pendingH264Frames.length,
@@ -558,16 +706,20 @@ class ImageRenderWorkerRuntime {
     const plan = applyH264HardLimit(this.#pendingH264Frames, true);
     this.#droppedH264Frames += plan.droppedFrames;
     this.#pendingH264Frames = plan.frames;
-    this.#h264WaitingForIdr = true;
-    this.#h264ConfigBeforeIdr = [...this.#h264RecentConfig];
+    this.#h264ProtectedQueueCount = 0;
+    this.#beginWaitForH264Idr();
     this.#resyncH264Decoder();
     this.#updateH264Pressure();
     this.#emitMetricsIfDue(true);
+    this.#requestH264Bootstrap();
   }
 
   #takeNextFrame(): ImageWorkerFrameEnvelope | null {
     const h264Frame = this.#pendingH264Frames.shift();
     if (h264Frame) {
+      if (this.#h264ProtectedQueueCount > 0) {
+        this.#h264ProtectedQueueCount -= 1;
+      }
       return h264Frame;
     }
     const frame = this.#pendingFrame;
@@ -740,19 +892,19 @@ class ImageRenderWorkerRuntime {
     this.#lastDecodedH264TimeNs = frameTimeNs;
     this.#h264DecodeMs = updateDecodeDurationEwma(this.#h264DecodeMs, output.decodeMs);
 
-    if (
-      this.#isPlaying &&
-      shouldDropDecodedH264Frame(this.#playbackTimeNs, frameTimeNs)
-    ) {
-      output.videoFrame.close();
-      this.#droppedH264Frames += 1;
-      this.#updateH264Pressure();
-      this.#emitMetricsIfDue();
-      return;
-    }
-
-    if (this.#pendingDecodedH264) {
-      this.#pendingDecodedH264.videoFrame.close();
+    // Newest-wins: the freshest decoded frame always takes the paint slot, so the
+    // canvas keeps advancing no matter how far behind the playhead the pipeline
+    // runs. Lateness alone is never a reason to discard output.
+    const pending = this.#pendingDecodedH264;
+    if (pending) {
+      if (isSupersededH264Output(frameTimeNs, timeToKey(pending.sourceFrame.receiveTime))) {
+        output.videoFrame.close();
+        this.#droppedH264Frames += 1;
+        this.#updateH264Pressure();
+        this.#emitMetricsIfDue();
+        return;
+      }
+      pending.videoFrame.close();
       this.#droppedH264Frames += 1;
     }
     this.#pendingDecodedH264 = {
@@ -796,20 +948,12 @@ class ImageRenderWorkerRuntime {
     const epoch = this.#epoch;
     const now = performance.now();
     try {
-      const frameTimeNs = timeToKey(sourceFrame.receiveTime);
-      if (
-        this.#isPlaying &&
-        shouldDropDecodedH264Frame(this.#playbackTimeNs, frameTimeNs)
-      ) {
-        this.#droppedH264Frames += 1;
-        return;
-      }
-
       const width = videoFrame.displayWidth || videoFrame.codedWidth;
       const height = videoFrame.displayHeight || videoFrame.codedHeight;
       this.#drawCanvasImageSource(videoFrame, width, height);
       this.#lastH264RenderAt = now;
       this.#renderedH264Frames += 1;
+      this.#noteH264Progress();
       this.#emitStatus({
         phase: 'ready',
         width,
@@ -846,6 +990,7 @@ class ImageRenderWorkerRuntime {
   }
 
   #handleH264DecoderError(error: Error): void {
+    console.warn('ImageRenderWorker: H.264 decode failed', error);
     this.#resyncH264Decoder();
     const recovery = selectLatestCompleteH264Gop(
       this.#pendingH264Frames,
@@ -854,14 +999,18 @@ class ImageRenderWorkerRuntime {
     );
     if (recovery.resync) {
       this.#pendingH264Frames = recovery.frames;
-      this.#h264WaitingForIdr = false;
+      this.#h264ProtectedQueueCount = 0;
+      this.#clearWaitForH264Idr();
       this.#droppedH264Frames += recovery.droppedFrames;
       void this.#drainLatestFrame();
     } else {
       this.#droppedH264Frames += this.#pendingH264Frames.length;
       this.#pendingH264Frames = [];
-      this.#h264WaitingForIdr = true;
-      this.#h264ConfigBeforeIdr = [...this.#h264RecentConfig];
+      this.#h264ProtectedQueueCount = 0;
+      this.#beginWaitForH264Idr();
+      // Nothing in the queue can restart decoding, and the next in-band IDR may
+      // never arrive, so pull a fresh GOP from before the current playhead.
+      this.#requestH264Bootstrap();
     }
     if (this.#renderedH264Frames === 0 && !this.#cachedFrame) {
       this.#emitStatus({ phase: 'error', message: error.message });
@@ -909,9 +1058,15 @@ class ImageRenderWorkerRuntime {
     this.#h264DecodeMs = 0;
     // After close()/configure(), WebCodecs requires the next VCL chunk to be an
     // IDR. Keep recent SPS/PPS so a bare IDR can still reconfigure the decoder.
-    this.#h264WaitingForIdr = true;
-    this.#h264ConfigBeforeIdr = [...this.#h264RecentConfig];
+    this.#beginWaitForH264Idr();
     this.#h264NeedsResync = false;
+    this.#h264LastEnqueuedTimeNs = null;
+    this.#h264FrameIntervalMs = 0;
+    this.#h264ProgressAt = null;
+    this.#h264StallReported = false;
+    // #lastH264BootstrapRequestAt is intentionally preserved: a bootstrap runs
+    // through here, so clearing it would let a bootstrap that fails to produce
+    // output immediately request another one.
     this.#lastH264RenderAt = -Infinity;
     this.#lastH264BitmapAt = -Infinity;
     this.#droppedH264Frames = 0;
@@ -942,6 +1097,7 @@ class ImageRenderWorkerRuntime {
       decodeQueueSize: this.#decoder.decodeQueueSize,
       mediaLagMs,
       resyncCount: this.#h264ResyncCount,
+      waitingForIdr: this.#h264WaitingForIdr,
       codec: this.#decoder.codec,
     };
     workerScope.postMessage({ type: 'metrics', metrics } satisfies ImageRenderWorkerEvent);

--- a/src/features/panels/Image/core/h264Backpressure.test.ts
+++ b/src/features/panels/Image/core/h264Backpressure.test.ts
@@ -5,7 +5,8 @@ import {
   decodedFrameLatenessMs,
   initialH264PressureState,
   isH264HardLimitExceeded,
-  shouldDropDecodedH264Frame,
+  isH264StreamDiscontinuity,
+  isSupersededH264Output,
   updateDecodeDurationEwma,
   updateH264Pressure,
 } from './h264Backpressure';
@@ -83,7 +84,7 @@ describe('H.264 adaptive backpressure', () => {
   it('uses actual media lag instead of playback speed', () => {
     const overloaded = updateH264Pressure(initialH264PressureState(), {
       ...healthy,
-      mediaLagMs: 400,
+      mediaLagMs: 2_000,
     });
     const capable = updateH264Pressure(initialH264PressureState(), healthy);
 
@@ -91,11 +92,58 @@ describe('H.264 adaptive backpressure', () => {
     expect(capable.mode).toBe('normal');
   });
 
-  it('drops decoded output only after it misses the media deadline', () => {
+  it('ignores steady transport latency so a bounded pipeline stays normal', () => {
+    // Six 720p streams decode with a few hundred ms of constant transport
+    // latency while the queues stay empty. That is not overload.
+    const transportLatency = { ...healthy, mediaLagMs: 260 };
+    let state = initialH264PressureState();
+    for (let i = 0; i < 30; i += 1) {
+      state = updateH264Pressure(state, transportLatency);
+    }
+    expect(state.mode).toBe('normal');
+  });
+
+  it('recovers from degraded while transport latency stays high', () => {
+    // Regression: gating recovery on media lag pinned the panel in degraded
+    // mode for the whole session, permanently halving the render rate.
+    let state: ReturnType<typeof updateH264Pressure> = {
+      mode: 'degraded',
+      healthySamples: 0,
+    };
+    const laggyButIdle = { ...healthy, mediaLagMs: 260 };
+    for (let i = 0; i < 20; i += 1) {
+      state = updateH264Pressure(state, laggyButIdle);
+    }
+    expect(state.mode).toBe('normal');
+  });
+
+  it('never discards a decoded frame that nothing newer supersedes', () => {
+    // Regression: an absolute output deadline discarded every frame once the
+    // pipeline's fixed latency exceeded it, freezing the canvas with no error.
     const playback = 1_000_000_000n;
     expect(decodedFrameLatenessMs(playback, 950_000_000n)).toBe(50);
-    expect(shouldDropDecodedH264Frame(playback, 900_000_000n)).toBe(false);
-    expect(shouldDropDecodedH264Frame(playback, 850_000_000n)).toBe(true);
-    expect(shouldDropDecodedH264Frame(null, 0n)).toBe(false);
+    expect(decodedFrameLatenessMs(playback, 700_000_000n)).toBe(300);
+    expect(isSupersededH264Output(700_000_000n, null)).toBe(false);
+    expect(isSupersededH264Output(0n, null)).toBe(false);
+  });
+
+  it('discards a decoded frame only for an equal-or-newer pending frame', () => {
+    expect(isSupersededH264Output(900_000_000n, 950_000_000n)).toBe(true);
+    expect(isSupersededH264Output(900_000_000n, 900_000_000n)).toBe(true);
+    expect(isSupersededH264Output(950_000_000n, 900_000_000n)).toBe(false);
+  });
+
+  it('treats only gaps beyond the observed cadence as a broken reference chain', () => {
+    expect(isH264StreamDiscontinuity(33, 33)).toBe(false);
+    expect(isH264StreamDiscontinuity(66, 33)).toBe(false);
+    expect(isH264StreamDiscontinuity(5_000, 33)).toBe(true);
+    // A low-rate stream's normal spacing must not read as a jump.
+    expect(isH264StreamDiscontinuity(500, 500)).toBe(false);
+    expect(isH264StreamDiscontinuity(2_100, 500)).toBe(true);
+  });
+
+  it('cannot judge continuity before a cadence is observed', () => {
+    expect(isH264StreamDiscontinuity(5_000, 0)).toBe(false);
+    expect(isH264StreamDiscontinuity(0, 33)).toBe(false);
   });
 });

--- a/src/features/panels/Image/core/h264Backpressure.ts
+++ b/src/features/panels/Image/core/h264Backpressure.ts
@@ -14,15 +14,19 @@ export interface H264PressureObservation {
 }
 
 /**
- * Hard pending-queue bounds. If the newest complete GOP still exceeds either
- * bound, the worker drops that backlog and waits for the next real IDR.
+ * Hard pending-queue bounds. Both bounds describe roughly the same backlog for a
+ * 30fps stream (120 frames ≈ 4s), so neither fires long before the other.
  */
 export const H264_MAX_PENDING_FRAMES = 120;
-export const H264_MAX_PENDING_SPAN_MS = 1_000;
+export const H264_MAX_PENDING_SPAN_MS = 4_000;
 export const H264_DECODE_QUEUE_HIGH_WATER = 4;
 export const H264_RENDER_INTERVAL_MS = 1000 / 60;
 export const H264_PRESSURED_RENDER_INTERVAL_MS = 1000 / 30;
-export const H264_OUTPUT_DEADLINE_MS = 120;
+
+/** Smallest inter-frame gap that can mark a broken reference chain. */
+export const H264_MIN_DISCONTINUITY_GAP_MS = 400;
+/** Multiple of the observed frame cadence that still counts as continuous. */
+export const H264_DISCONTINUITY_CADENCE_FACTOR = 4;
 
 const ENTER_DEGRADED = {
   frames: 72,
@@ -31,21 +35,29 @@ const ENTER_DEGRADED = {
   // A full bounded decode pipeline is healthy by itself. Only treat the
   // decoder queue as overload when it exceeds the configured feeder bound.
   decodeQueueSize: H264_DECODE_QUEUE_HIGH_WATER * 2,
-  mediaLagMs: 350,
+  // Media lag also carries the pipeline's fixed transport latency, which on
+  // multi-stream 720p recordings sits in the hundreds of milliseconds. Only
+  // treat it as overload once it is far beyond any plausible transport cost.
+  mediaLagMs: 1_500,
 };
+/**
+ * Recovery deliberately omits `mediaLagMs`: it is dominated by constant
+ * transport latency rather than by overload, so gating recovery on it pins the
+ * panel in `degraded` for the whole session (halved render rate, DPR clamped
+ * to 1) on any recording whose latency never drops below the bound.
+ */
 const ENTER_RECOVERY = {
   frames: 18,
   spanMs: 120,
   decodeMs: 32,
   decodeQueueSize: 1,
-  mediaLagMs: 120,
 };
 const RELAPSE = {
   frames: 40,
   spanMs: 250,
   decodeMs: 45,
   decodeQueueSize: H264_DECODE_QUEUE_HIGH_WATER + 2,
-  mediaLagMs: 250,
+  mediaLagMs: 1_000,
 };
 const RECOVERY_SAMPLES = 12;
 
@@ -75,8 +87,7 @@ export function updateH264Pressure(
     observation.queueFrames <= ENTER_RECOVERY.frames &&
     observation.queueSpanMs <= ENTER_RECOVERY.spanMs &&
     observation.decodeMs <= ENTER_RECOVERY.decodeMs &&
-    observation.decodeQueueSize <= ENTER_RECOVERY.decodeQueueSize &&
-    observation.mediaLagMs <= ENTER_RECOVERY.mediaLagMs;
+    observation.decodeQueueSize <= ENTER_RECOVERY.decodeQueueSize;
   const relapsed =
     observation.queueFrames >= RELAPSE.frames ||
     observation.queueSpanMs >= RELAPSE.spanMs ||
@@ -116,10 +127,46 @@ export function decodedFrameLatenessMs(playbackTimeNs: bigint | null, frameTimeN
   return Math.max(0, Number(playbackTimeNs - frameTimeNs) / 1_000_000);
 }
 
-export function shouldDropDecodedH264Frame(
-  playbackTimeNs: bigint | null,
-  frameTimeNs: bigint,
-  deadlineMs = H264_OUTPUT_DEADLINE_MS,
+/**
+ * Newest-wins output policy.
+ *
+ * The delay between the playhead passing a frame and its `VideoFrame` arriving
+ * (player tick, `postMessage`, decode queue, `VideoDecoder`) is a fixed property
+ * of the pipeline and routinely reaches several hundred milliseconds when
+ * several 720p streams decode at once. Lateness on its own therefore says
+ * nothing about whether a frame is worth painting, and discarding late frames
+ * against a wall-clock budget strands the canvas on whichever frame happened to
+ * beat it — a permanently frozen image with no error.
+ *
+ * A decoded frame is disposable only when an equal-or-newer decoded frame is
+ * already waiting to be painted in its place.
+ */
+export function isSupersededH264Output(
+  candidateTimeNs: bigint,
+  pendingTimeNs: bigint | null,
 ): boolean {
-  return decodedFrameLatenessMs(playbackTimeNs, frameTimeNs) > deadlineMs;
+  return pendingTimeNs != null && pendingTimeNs >= candidateTimeNs;
+}
+
+/**
+ * True when a gap between consecutive frames is too large to be the stream's
+ * natural cadence, meaning the reference chain a delta frame depends on was
+ * never decoded (forward seek, loop wrap, or a skipped backlog).
+ *
+ * Returns false while the cadence is still unknown (`frameIntervalMs <= 0`),
+ * since a low-rate stream's normal spacing is indistinguishable from a jump
+ * until at least one interval has been observed.
+ */
+export function isH264StreamDiscontinuity(
+  gapMs: number,
+  frameIntervalMs: number,
+  minGapMs = H264_MIN_DISCONTINUITY_GAP_MS,
+): boolean {
+  if (!Number.isFinite(gapMs) || gapMs <= 0) {
+    return false;
+  }
+  if (!Number.isFinite(frameIntervalMs) || frameIntervalMs <= 0) {
+    return false;
+  }
+  return gapMs > Math.max(minGapMs, frameIntervalMs * H264_DISCONTINUITY_CADENCE_FACTOR);
 }

--- a/src/features/panels/Image/core/h264SeekRepair.ts
+++ b/src/features/panels/Image/core/h264SeekRepair.ts
@@ -9,8 +9,15 @@ import { getH264MessagePayload, isH264MessageEvent, toWorkerFrame } from './mess
 /** Progressive lookback windows when searching for a keyframe before a seek target. */
 export const H264_SEEK_WINDOWS_MS = [2000, 5000, 10_000, 30_000] as const;
 
-/** Maximum frame messages posted for one seek repair. */
-export const H264_SEEK_MAX_FRAMES = 180;
+/**
+ * Maximum frame messages posted for one seek repair.
+ *
+ * Must exceed one GOP for the recordings we support, otherwise a seek target
+ * further than this from its IDR silently lands on the wrong frame. Robot
+ * recordings routinely use a 256-frame (8.5s at 30fps) keyframe interval, and
+ * some carry a single IDR for the whole file.
+ */
+export const H264_SEEK_MAX_FRAMES = 600;
 
 /** Forward read when bootstrapping at/before the file's first IDR. */
 export const H264_BOOTSTRAP_FORWARD_MS = 2_000;

--- a/src/features/panels/Image/core/imageTypes.ts
+++ b/src/features/panels/Image/core/imageTypes.ts
@@ -27,7 +27,8 @@ export interface CompressedVideoMessage {
 }
 
 export interface ImageSurfaceStatus {
-  phase: 'idle' | 'decoding' | 'ready' | 'error';
+  /** `stalled`: frames keep arriving but none of them reach the canvas. */
+  phase: 'idle' | 'decoding' | 'ready' | 'stalled' | 'error';
   width?: number;
   height?: number;
   encoding?: string;

--- a/src/features/panels/Image/core/imageWorkerProtocol.ts
+++ b/src/features/panels/Image/core/imageWorkerProtocol.ts
@@ -86,6 +86,8 @@ export interface ImageRenderMetrics {
   decodeQueueSize: number;
   mediaLagMs: number;
   resyncCount: number;
+  /** True while every incoming frame is discarded pending a random-access point. */
+  waitingForIdr: boolean;
   codec?: string;
 }
 
@@ -97,4 +99,13 @@ export type ImageRenderWorkerEvent =
   | {
       type: 'metrics';
       metrics: ImageRenderMetrics;
+    }
+  /**
+   * The worker cannot resume decoding from the frames it has. The panel should
+   * fetch a bootstrap batch starting at the nearest IDR before the playhead.
+   * Waiting for the next in-band IDR is not viable: keyframe intervals of
+   * several seconds are common and some recordings hold a single IDR.
+   */
+  | {
+      type: 'needsBootstrap';
     };


### PR DESCRIPTION
## Summary
- Fix H.264 image panels freezing on the first frame with no error when playing `foxglove_msgs/msg/CompressedVideo` streams (especially multi-camera 720p MCAP recordings with long GOPs or a single IDR).
- Replace the absolute 120ms output-deadline drop with a newest-wins render policy so decoded frames always reach the canvas under normal pipeline latency.
- Recover pressure mode under steady transport latency, protect in-flight bootstrap GOPs from queue trimming, widen seek/repair bounds for 256-frame GOPs, and actively re-bootstrap when passive IDR wait would never complete.

## Root cause
The worker silently closed every decoded `VideoFrame` once `receiveTime` lagged the playhead by more than 120ms. On six concurrent 720p streams the end-to-end latency is ~180–270ms, so `rendered=0` while `dropped` climbed with no UI error.

## Test plan
- [x] `npm run lint`
- [x] `npm test` (692 passed)
- [x] Manual playback verified on `E45CF00A_1782467198053__1_3.mcap` and `_1_6.mcap`
- [ ] CI green on PR